### PR TITLE
Database schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-01-24
+
+### Added
+
+- Support to create the mssql login with SID
+- New Data source mssql_login
+- New resource database permission
+- New resource mssql role
+
+
 ## [0.3.0] - 2023-12-29
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-VERSION	= 0.3.0
+VERSION	= 0.3.1
 
 TERRAFORM	  = terraform
 TERRAFORM_VERSION = "~> 1.5"

--- a/docs/resources/database_schema.md
+++ b/docs/resources/database_schema.md
@@ -1,13 +1,13 @@
 # mssql_database_role
 
-The `mssql_database_role` resource creates and manages a role on a SQL Server database.
+The `mssql_database_schema` resource creates and manages a schema on a SQL Server database.
 
 ## Example Usage
 
 ### Basic usage
 
 ```hcl
-resource "mssql_database_role" "example" {
+resource "mssql_database_schema" "example" {
   server {
     host = "example-sql-server.database.windows.net"
     azure_login {
@@ -17,7 +17,7 @@ resource "mssql_database_role" "example" {
     }
   }
   database      = "master"
-  role_name     = "example-role-name"
+  schema_name     = "example-schema-name"
 }
 ```
 
@@ -34,7 +34,7 @@ resource "mssql_database_role" "example" {
     }
   }
   database   = "my-database"
-  role_name  = "example-role-name"
+  schema_name  = "example-schema-name"
   owner_name = "example_username"
 }
 ```
@@ -44,9 +44,9 @@ resource "mssql_database_role" "example" {
 The following arguments are supported:
 
 * `server` - (Required) Server and login details for the SQL Server. The attributes supported in the `server` block is detailed below.
-* `role_name` - (Required) The name of the role. Changing this resource property modifies the existing resource.
-* `database` - (Optional) The role will be created in this database. Defaults to `master`. Changing this forces a new resource to be created.
-* `owner_name` - (Optional) Is the database user or role that is to own the new role. Changing this resource property modifies the existing resource.
+* `schema_name` - (Required) The name of the schema. Changing this forces a new resource to be created.
+* `database` - (Optional) The schema will be created in this database. Defaults to `master`. Changing this forces a new resource to be created.
+* `owner_name` - (Optional) Is the database user that is to own the new schema. Changing this resource property modifies the existing resource.
 
 The `server` block supports the following arguments:
 
@@ -64,13 +64,13 @@ The `login` block supports the following arguments:
 
 The following attributes are exported:
 
-* `principal_id` - The principal id of this database role.
-* `owner_name` - The database user name or role name that is own the role.
-* `owning_principal_id` - The database user id or the role id that is own the role.
+* `schema_id` - The schema id of this database schema.
+* `owner_name` - The database user name that is own the schema.
+* `owning_principal_id` - The database user id that is own the role.
 
 ## Import
 
-Before importing `mssql_database_role`, you must to configure the authentication to your sql server:
+Before importing `mssql_database_schema`, you must to configure the authentication to your sql server:
 
 1. Using Azure AD authentication, you must set the following environment variables: `MSSQL_TENANT_ID`, `MSSQL_CLIENT_ID` and `MSSQL_CLIENT_SECRET`.
 2. Using SQL authentication, you must set the following environment variables: `MSSQL_USERNAME` and `MSSQL_PASSWORD`.
@@ -78,5 +78,5 @@ Before importing `mssql_database_role`, you must to configure the authentication
 After that you can import the SQL Server database role using the server URL and `role name`, e.g.
 
 ```shell
-terraform import mssql_database_role.example 'mssql://example-sql-server.database.windows.net/master/testrole'
+terraform import mssql_database_schema.example 'mssql://example-sql-server.database.windows.net/master/testschema'
 ```

--- a/examples/azure/main.tf
+++ b/examples/azure/main.tf
@@ -321,3 +321,30 @@ resource "mssql_database_permissions" "example" {
     "INSERT",
   ]
 }
+
+resource "mssql_database_schema" "example" {
+  server {
+    host = azurerm_mssql_server.sql_server.fully_qualified_domain_name
+    azure_login {
+      tenant_id     = var.tenant_id
+      client_id     = azuread_service_principal.sa.client_id
+      client_secret = azuread_service_principal_password.sa.value
+    }
+  }
+  database = "master"
+  schema_name = "testschema"
+}
+
+resource "mssql_database_schema" "example_authorization" {
+  server {
+    host = azurerm_mssql_server.sql_server.fully_qualified_domain_name
+    azure_login {
+      tenant_id     = var.tenant_id
+      client_id     = azuread_service_principal.sa.client_id
+      client_secret = azuread_service_principal_password.sa.value
+    }
+  }
+  database = "my-database"
+  schema_name = "testschema"
+  owner_name = mssql_user.external.username
+}

--- a/examples/local/main.tf
+++ b/examples/local/main.tf
@@ -175,3 +175,28 @@ resource "mssql_database_permissions" "example" {
     "INSERT",
   ]
 }
+
+resource "mssql_database_schema" "example" {
+  server {
+    host = docker_container.mssql.ip_address
+    login {
+      username = local.local_username
+      password = local.local_password
+    }
+  }
+  database = "master"
+  schema_name = "testschema"
+}
+
+resource "mssql_database_schema" "example_authorization" {
+  server {
+    host = docker_container.mssql.ip_address
+    login {
+      username = local.local_username
+      password = local.local_password
+    }
+  }
+  database = "example-db"
+  schema_name = "example-schema"
+  owner_name = mssql_user.example.username
+}

--- a/mssql/const.go
+++ b/mssql/const.go
@@ -16,4 +16,9 @@ const (
   loginNameProp            = "login_name"
   permissionsProp          = "permissions"
   roleNameProp             = "role_name"
+  schemaNameProp           = "schema_name"
+  ownerNameProp            = "owner_name"
+  ownerIdProp              = "owning_principal_id"
+  schemaIdProp             = "schema_id"
+  defaultOwnerNameDefault  = "dbo"
 )

--- a/mssql/model/database_schema.go
+++ b/mssql/model/database_schema.go
@@ -1,0 +1,10 @@
+
+package model
+
+// Schema represents a SQL Server schema
+type DatabaseSchema struct {
+  SchemaID   int
+  SchemaName string
+  OwnerName  string
+  OwnerId    int
+}

--- a/mssql/provider.go
+++ b/mssql/provider.go
@@ -47,7 +47,8 @@ func Provider(factory model.ConnectorFactory) *schema.Provider {
       "mssql_login": resourceLogin(),
       "mssql_user":  resourceUser(),
       "mssql_database_permissions": resourceDatabasePermissions(),
-      "mssql_database_role":  resourceDatabaseRole(),
+      "mssql_database_role": resourceDatabaseRole(),
+      "mssql_database_schema": resourceDatabaseSchema(),
     },
     DataSourcesMap: map[string]*schema.Resource{
       "mssql_login": dataLogin(),

--- a/mssql/provider_test.go
+++ b/mssql/provider_test.go
@@ -63,6 +63,7 @@ type TestConnector interface {
   GetUser(database, name string) (*model.User, error)
   GetDatabasePermissions(database string, principalId int) (*model.DatabasePermissions, error)
   GetDatabaseRole(database, name string) (*model.DatabaseRole, error)
+  GetDatabaseSchema(database, name string) (*model.DatabaseSchema, error)
   GetSystemUser() (string, error)
   GetCurrentUser(database string) (string, string, error)
 }
@@ -166,6 +167,10 @@ func (t testConnector) GetDatabasePermissions(database string, principalId int) 
 
 func (t testConnector) GetDatabaseRole(database string, roleName string) (*model.DatabaseRole, error) {
   return t.c.(DatabaseRoleConnector).GetDatabaseRole(context.Background(), database, roleName)
+}
+
+func (t testConnector) GetDatabaseSchema(database string, schemaName string) (*model.DatabaseSchema, error) {
+  return t.c.(DatabaseSchemaConnector).GetDatabaseSchema(context.Background(), database, schemaName)
 }
 
 func (t testConnector) GetSystemUser() (string, error) {

--- a/mssql/resource_database_role.go
+++ b/mssql/resource_database_role.go
@@ -9,10 +9,6 @@ import (
   "github.com/pkg/errors"
 )
 
-const ownerIdProp   = "owning_principal_id"
-const ownerNameProp = "owner_name"
-const defaultOwnerNameDefault = "dbo"
-
 func resourceDatabaseRole() *schema.Resource {
   return &schema.Resource{
     CreateContext: resourceDatabaseRoleCreate,

--- a/mssql/resource_database_role_test.go
+++ b/mssql/resource_database_role_test.go
@@ -203,7 +203,7 @@ func TestAccRole_Local_Basic_Update_remove_owner(t *testing.T) {
   })
 }
 
-func TestAccRole_Local_Basic_Update_Role_and_owner(t *testing.T) {
+func TestAccRole_Local_Basic_Update_role_and_owner(t *testing.T) {
   resource.Test(t, resource.TestCase{
     PreCheck:          func() { testAccPreCheck(t) },
     IsUnitTest:        runLocalAccTests,
@@ -391,7 +391,7 @@ func testAccCheckRoleDestroy(state *terraform.State) error {
     }
 
     database := rs.Primary.Attributes["database"]
-    roleName := rs.Primary.Attributes["username"]
+    roleName := rs.Primary.Attributes["role_name"]
     role, err := connector.GetDatabaseRole(database, roleName)
     if role != nil {
       return fmt.Errorf("role still exists")

--- a/mssql/resource_database_schema.go
+++ b/mssql/resource_database_schema.go
@@ -1,0 +1,242 @@
+package mssql
+
+import (
+  "context"
+  "strings"
+  "github.com/betr-io/terraform-provider-mssql/mssql/model"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+  "github.com/pkg/errors"
+)
+
+func resourceDatabaseSchema() *schema.Resource {
+  return &schema.Resource{
+    CreateContext: resourceDatabaseSchemaCreate,
+    ReadContext:   resourceDatabaseSchemaRead,
+    UpdateContext: resourceDatabaseSchemaUpdate,
+    DeleteContext: resourceDatabaseSchemaDelete,
+    Importer: &schema.ResourceImporter{
+      StateContext: resourceDatabaseSchemaImport,
+    },
+    Schema: map[string]*schema.Schema{
+      serverProp: {
+        Type:     schema.TypeList,
+        MaxItems: 1,
+        Required: true,
+        Elem: &schema.Resource{
+          Schema: getServerSchema(serverProp),
+        },
+      },
+      databaseProp: {
+        Type:     schema.TypeString,
+        Optional: true,
+        ForceNew: true,
+        Default:  "master",
+      },
+      schemaNameProp: {
+        Type:     schema.TypeString,
+        Required: true,
+        ForceNew: true,
+      },
+      ownerNameProp: {
+        Type:     schema.TypeString,
+        Optional: true,
+        Default:  defaultOwnerNameDefault,
+        DiffSuppressFunc: func(k, old, new string, data *schema.ResourceData) bool {
+          return (old == "" && new == defaultOwnerNameDefault) || (old == defaultOwnerNameDefault && new == "")
+        },
+      },
+      schemaIdProp: {
+        Type:     schema.TypeInt,
+        Computed: true,
+      },
+      ownerIdProp: {
+        Type:     schema.TypeInt,
+        Computed: true,
+      },
+    },
+    Timeouts: &schema.ResourceTimeout{
+      Default: defaultTimeout,
+    },
+  }
+}
+
+type DatabaseSchemaConnector interface {
+  CreateDatabaseSchema(ctx context.Context, database string, schemaName string, ownerName string) error
+  GetDatabaseSchema(ctx context.Context, database, schemaName string) (*model.DatabaseSchema, error)
+  UpdateDatabaseSchema(ctx context.Context, database string, schemaName string, ownerName string) error
+  DeleteDatabaseSchema(ctx context.Context, database, schemaName string) error
+}
+
+func resourceDatabaseSchemaRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+  logger := loggerFromMeta(meta, "schema", "read")
+  logger.Debug().Msgf("Read %s", getDatabaseSchemaID(data))
+
+  database := data.Get(databaseProp).(string)
+  schemaName := data.Get(schemaNameProp).(string)
+
+  connector, err := getDatabaseSchemaConnector(meta, data)
+  if err != nil {
+    return diag.FromErr(err)
+  }
+
+  sqlschema, err := connector.GetDatabaseSchema(ctx, database, schemaName)
+  if err != nil {
+    return diag.FromErr(errors.Wrapf(err, "unable to get schema [%s].[%s]", database, schemaName))
+  }
+
+  if sqlschema == nil {
+    logger.Info().Msgf("schema [%s].[%s] does not exist", database, schemaName)
+    data.SetId("")
+  } else {
+    if err = data.Set(schemaIdProp, sqlschema.SchemaID); err != nil {
+      return diag.FromErr(err)
+    }
+    if err = data.Set(schemaNameProp, sqlschema.SchemaName); err != nil {
+      return diag.FromErr(err)
+    }
+    if err = data.Set(ownerNameProp, sqlschema.OwnerName); err != nil {
+      return diag.FromErr(err)
+    }
+    if err = data.Set(ownerIdProp, sqlschema.OwnerId); err != nil {
+      return diag.FromErr(err)
+    }
+  }
+
+  logger.Info().Msgf("read schema [%s].[%s]", database, schemaName)
+
+  return nil
+}
+
+func resourceDatabaseSchemaCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+  logger := loggerFromMeta(meta, "schema", "create")
+  logger.Debug().Msgf("Create %s", getDatabaseSchemaID(data))
+
+  database := data.Get(databaseProp).(string)
+  schemaName := data.Get(schemaNameProp).(string)
+  ownerName := data.Get(ownerNameProp).(string)
+
+  connector, err := getDatabaseSchemaConnector(meta, data)
+  if err != nil {
+    return diag.FromErr(err)
+  }
+
+  if err = connector.CreateDatabaseSchema(ctx, database, schemaName, ownerName); err != nil {
+    return diag.FromErr(errors.Wrapf(err, "unable to create schema [%s].[%s]", database, schemaName))
+  }
+
+  data.SetId(getDatabaseSchemaID(data))
+
+  logger.Info().Msgf("created schema [%s].[%s]", database, schemaName)
+
+  return resourceDatabaseSchemaRead(ctx, data, meta)
+}
+
+func resourceDatabaseSchemaDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+  logger := loggerFromMeta(meta, "schema", "delete")
+  logger.Debug().Msgf("Delete %s", getDatabaseSchemaID(data))
+
+  database := data.Get(databaseProp).(string)
+  schemaName := data.Get(schemaNameProp).(string)
+
+  connector, err := getDatabaseSchemaConnector(meta, data)
+  if err != nil {
+    return diag.FromErr(err)
+  }
+
+  if err = connector.DeleteDatabaseSchema(ctx, database, schemaName); err != nil {
+    return diag.FromErr(errors.Wrapf(err, "unable to delete schema [%s].[%s]", database, schemaName))
+  }
+
+  // d.SetId("") is automatically called assuming delete returns no errors, but it is added here for explicitness.
+  data.SetId("")
+
+  logger.Info().Msgf("deleted schema [%s].[%s]", database, schemaName)
+
+  return nil
+}
+
+func resourceDatabaseSchemaUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+  logger := loggerFromMeta(meta, "schema", "update")
+  logger.Debug().Msgf("Update %s", getDatabaseSchemaID(data))
+
+  database := data.Get(databaseProp).(string)
+  schemaName := data.Get(schemaNameProp).(string)
+  ownerName := data.Get(ownerNameProp).(string)
+
+  connector, err := getDatabaseSchemaConnector(meta, data)
+  if err != nil {
+    return diag.FromErr(err)
+  }
+
+  if err = connector.UpdateDatabaseSchema(ctx, database, schemaName, ownerName); err != nil {
+    return diag.FromErr(errors.Wrapf(err, "unable to update schema [%s].[%s]", database, schemaName))
+  }
+
+  data.SetId(getDatabaseSchemaID(data))
+
+  logger.Info().Msgf("updated schema [%s].[%s]", database, schemaName)
+
+  return resourceDatabaseSchemaRead(ctx, data, meta)
+}
+
+func resourceDatabaseSchemaImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+  logger := loggerFromMeta(meta, "schema", "import")
+  logger.Debug().Msgf("Import %s", data.Id())
+
+  server, u, err := serverFromId(data.Id())
+  if err != nil {
+    return nil, err
+  }
+  if err := data.Set(serverProp, server); err != nil {
+    return nil, err
+  }
+
+  parts := strings.Split(u.Path, "/")
+  if len(parts) != 3 {
+    return nil, errors.New("invalid ID")
+  }
+  if err = data.Set(databaseProp, parts[1]); err != nil {
+    return nil, err
+  }
+  if err = data.Set(schemaNameProp, parts[2]); err != nil {
+    return nil, err
+  }
+
+  data.SetId(getDatabaseSchemaID(data))
+
+  database := data.Get(databaseProp).(string)
+  schemaName := data.Get(schemaNameProp).(string)
+
+  connector, err := getDatabaseSchemaConnector(meta, data)
+  if err != nil {
+    return nil, err
+  }
+
+  sqlschema, err := connector.GetDatabaseSchema(ctx, database, schemaName)
+  if err != nil {
+    return nil, errors.Wrapf(err, "unable to get schema [%s].[%s]", database, schemaName)
+  }
+
+  if sqlschema == nil {
+    return nil, errors.Errorf("schema [%s].[%s] does not exist", database, schemaName)
+  }
+
+  if err = data.Set(schemaIdProp, sqlschema.SchemaID); err != nil {
+    return nil, err
+  }
+  if err = data.Set(ownerNameProp, sqlschema.OwnerName); err != nil {
+    return nil, err
+  }
+
+  return []*schema.ResourceData{data}, nil
+}
+
+func getDatabaseSchemaConnector(meta interface{}, data *schema.ResourceData) (DatabaseSchemaConnector, error) {
+  provider := meta.(model.Provider)
+  connector, err := provider.GetConnector(serverProp, data)
+  if err != nil {
+    return nil, err
+  }
+  return connector.(DatabaseSchemaConnector), nil
+}

--- a/mssql/resource_database_schema_import_test.go
+++ b/mssql/resource_database_schema_import_test.go
@@ -1,0 +1,30 @@
+package mssql
+
+import (
+  "testing"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccSchema_Local_BasicImport(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    IsUnitTest:        runLocalAccTests,
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "test_import", "login", map[string]interface{}{"schema_name": "test_schema_import"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.test_import"),
+        ),
+      },
+      {
+        ResourceName:      "mssql_database_schema.test_import",
+        ImportState:       true,
+        ImportStateVerify: true,
+        ImportStateIdFunc: testAccImportStateId("mssql_database_schema.test_import", false),
+      },
+    },
+  })
+}

--- a/mssql/resource_database_schema_test.go
+++ b/mssql/resource_database_schema_test.go
@@ -1,0 +1,351 @@
+package mssql
+
+import (
+  "fmt"
+  "os"
+  "testing"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccSchema_Local_Basic_Create(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    IsUnitTest:        runLocalAccTests,
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "local_test_create", "login", map[string]interface{}{"schema_name": "test_schema_create"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.local_test_create"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "database", "master"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "schema_name", "test_schema_create"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "server.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "server.0.host", "localhost"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "server.0.port", "1433"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "server.0.login.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "server.0.login.0.username", os.Getenv("MSSQL_USERNAME")),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "server.0.login.0.password", os.Getenv("MSSQL_PASSWORD")),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_create", "server.0.azure_login.#", "0"),
+          resource.TestCheckResourceAttrSet("mssql_database_schema.local_test_create", "schema_id"),
+          resource.TestCheckNoResourceAttr("mssql_database_schema.local_test_create", "password"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccSchema_Local_Basic_Create_owner(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    IsUnitTest:        runLocalAccTests,
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "test_create_auth", "login", map[string]interface{}{"database": "master", "schema_name": "test_schema_auth", "owner_name": "db_user_schema", "username": "db_user_schema", "login_name": "db_login_schema", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.test_create_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "database", "master"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "schema_name", "test_schema_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "owner_name", "db_user_schema"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "server.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "server.0.host", "localhost"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "server.0.port", "1433"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "server.0.login.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "server.0.login.0.username", os.Getenv("MSSQL_USERNAME")),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "server.0.login.0.password", os.Getenv("MSSQL_PASSWORD")),
+          resource.TestCheckResourceAttr("mssql_database_schema.test_create_auth", "server.0.azure_login.#", "0"),
+          resource.TestCheckResourceAttrSet("mssql_database_schema.test_create_auth", "schema_id"),
+          resource.TestCheckNoResourceAttr("mssql_database_schema.test_create_auth", "password"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccSchema_Azure_Basic_Create(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "azure_test_create", "azure", map[string]interface{}{"database":"testdb", "schema_name": "test_schema_create"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.azure_test_create"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "database", "testdb"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "schema_name", "test_schema_create"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.0.host", os.Getenv("TF_ACC_SQL_SERVER")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.0.port", "1433"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.0.azure_login.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.0.azure_login.0.tenant_id", os.Getenv("MSSQL_TENANT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.0.azure_login.0.client_id", os.Getenv("MSSQL_CLIENT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.0.azure_login.0.client_secret", os.Getenv("MSSQL_CLIENT_SECRET")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create", "server.0.login.#", "0"),
+          resource.TestCheckResourceAttrSet("mssql_database_schema.azure_test_create", "schema_id"),
+          resource.TestCheckNoResourceAttr("mssql_database_schema.azure_test_create", "password"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccSchema_Azure_Basic_Create_owner(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "azure_test_create_auth", "azure", map[string]interface{}{"database": "testdb", "schema_name": "test_schema_auth", "owner_name": "db_user_schema", "username": "db_user_schema", "password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.azure_test_create_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "database", "testdb"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "schema_name", "test_schema_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "owner_name", "db_user_schema"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.0.host", os.Getenv("TF_ACC_SQL_SERVER")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.0.port", "1433"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.0.azure_login.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.0.azure_login.0.tenant_id", os.Getenv("MSSQL_TENANT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.0.azure_login.0.client_id", os.Getenv("MSSQL_CLIENT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.0.azure_login.0.client_secret", os.Getenv("MSSQL_CLIENT_SECRET")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_create_auth", "server.0.login.#", "0"),
+          resource.TestCheckResourceAttrSet("mssql_database_schema.azure_test_create_auth", "schema_id"),
+          resource.TestCheckNoResourceAttr("mssql_database_schema.azure_test_create_auth", "password"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccSchema_Local_Basic_Update_owner(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    IsUnitTest:        runLocalAccTests,
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "local_test_update_auth", "login", map[string]interface{}{"database": "master", "schema_name": "test_schema_owner", "owner_name": "db_user_owner_pre", "username": "db_user_owner_pre", "login_name": "db_login_owner1", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.local_test_update_auth", Check{"owner_name", "==", "db_user_owner_pre"}),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_auth", "schema_name", "test_schema_owner"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_auth", "owner_name", "db_user_owner_pre"),
+        ),
+      },
+      {
+        Config: testAccCheckSchema(t, "local_test_update_auth", "login", map[string]interface{}{"database": "master", "schema_name": "test_schema_owner", "owner_name": "db_user_owner_post", "username": "db_user_owner_post", "login_name": "db_login_owner2", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.local_test_update_auth", Check{"owner_name", "==", "db_user_owner_post"}),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_auth", "schema_name", "test_schema_owner"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_auth", "owner_name", "db_user_owner_post"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccSchema_Local_Basic_Update_remove_owner(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    IsUnitTest:        runLocalAccTests,
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "local_test_update_rm_auth", "login", map[string]interface{}{"database": "master", "schema_name": "test_schema_owner_rm", "owner_name": "db_user_owner_rm", "username": "db_user_owner_rm", "login_name": "db_login_owner_rm", "login_password": "valueIsH8kd$¡"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.local_test_update_rm_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_rm_auth", "schema_name", "test_schema_owner_rm"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_rm_auth", "owner_name", "db_user_owner_rm"),
+        ),
+      },
+      {
+        Config: testAccCheckSchema(t, "local_test_update_rm_auth", "login", map[string]interface{}{"database": "master", "schema_name": "test_schema_owner_rm", "owner_name": "", "username": "db_user_owner_rm", "login_name": "db_login_owner_rm", "login_password": "valueIsH8kd$¡"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.local_test_update_rm_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_rm_auth", "schema_name", "test_schema_owner_rm"),
+          resource.TestCheckResourceAttr("mssql_database_schema.local_test_update_rm_auth", "owner_name", "dbo"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccSchema_Azure_Basic_Update_owner(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckSchemaDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckSchema(t, "azure_test_update_owner", "azure", map[string]interface{}{"database": "testdb", "schema_name": "test_schema_auth", "owner_name": "db_user_schema", "username": "db_user_schema", "password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.azure_test_update_owner"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "database", "testdb"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "schema_name", "test_schema_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "owner_name", "db_user_schema"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.host", os.Getenv("TF_ACC_SQL_SERVER")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.port", "1433"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.0.tenant_id", os.Getenv("MSSQL_TENANT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.0.client_id", os.Getenv("MSSQL_CLIENT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.0.client_secret", os.Getenv("MSSQL_CLIENT_SECRET")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.login.#", "0"),
+          resource.TestCheckResourceAttrSet("mssql_database_schema.azure_test_update_owner", "schema_id"),
+          resource.TestCheckNoResourceAttr("mssql_database_schema.azure_test_update_owner", "password"),
+        ),
+      },
+      {
+        Config: testAccCheckSchema(t, "azure_test_update_owner", "azure", map[string]interface{}{"database": "testdb", "schema_name": "test_schema_auth", "username": "db_user_schema", "password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckSchemaExists("mssql_database_schema.azure_test_update_owner"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "database", "testdb"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "schema_name", "test_schema_auth"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "owner_name", "dbo"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.host", os.Getenv("TF_ACC_SQL_SERVER")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.port", "1433"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.#", "1"),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.0.tenant_id", os.Getenv("MSSQL_TENANT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.0.client_id", os.Getenv("MSSQL_CLIENT_ID")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.azure_login.0.client_secret", os.Getenv("MSSQL_CLIENT_SECRET")),
+          resource.TestCheckResourceAttr("mssql_database_schema.azure_test_update_owner", "server.0.login.#", "0"),
+          resource.TestCheckResourceAttrSet("mssql_database_schema.azure_test_update_owner", "schema_id"),
+          resource.TestCheckNoResourceAttr("mssql_database_schema.azure_test_update_owner", "password"),
+        ),
+      },
+    },
+  })
+}
+
+func testAccCheckSchema(t *testing.T, name string, login string, data map[string]interface{}) string {
+  text := `{{ if .login_name }}
+           resource "mssql_login" "{{ .name }}" {
+             server {
+               host = "{{ .host }}"
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+             }
+             login_name = "{{ .login_name }}"
+             password   = "{{ .login_password }}"
+           }
+           {{ end }}
+           {{ if .username }}
+           resource "mssql_user" "{{ .name }}" {
+             server {
+               host = "{{ .host }}"
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+             }
+             {{ with .database }}database = "{{ . }}"{{ end }}
+             username = "{{ .username }}"
+             {{ with .password }}password = "{{ . }}"{{ end }}
+             {{ with .login_name }}login_name = "{{ . }}"{{ end }}
+             {{ with .default_schema }}default_schema = "{{ . }}"{{ end }}
+             {{ with .default_language }}default_language = "{{ . }}"{{ end }}
+             {{ with .roles }}roles = {{ . }}{{ end }}
+           }
+           {{ end }}
+           resource "mssql_database_schema" "{{ .name }}" {
+             server {
+               host = "{{ .host }}"
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+             }
+             {{ with .database }}database = "{{ . }}"{{ end }}
+             schema_name = "{{ .schema_name }}"
+             {{ with .owner_name }}owner_name = "{{ . }}"{{ end }}
+             {{ if .username }}
+             depends_on = [mssql_user.{{ .name }}]
+             {{ end }}
+           }`
+
+  data["name"] = name
+  data["login"] = login
+  if login == "fedauth" || login == "msi" || login == "azure" {
+    data["host"] = os.Getenv("TF_ACC_SQL_SERVER")
+  } else if login == "login" {
+    data["host"] = "localhost"
+  } else {
+    t.Fatalf("login expected to be one of 'login', 'azure', 'msi', 'fedauth', got %s", login)
+  }
+  res, err := templateToString(name, text, data)
+  if err != nil {
+    t.Fatalf("%s", err)
+  }
+  return res
+}
+
+func testAccCheckSchemaDestroy(state *terraform.State) error {
+  for _, rs := range state.RootModule().Resources {
+    if rs.Type != "mssql_database_schema" {
+      continue
+    }
+
+    connector, err := getTestConnector(rs.Primary.Attributes)
+    if err != nil {
+      return err
+    }
+
+    database := rs.Primary.Attributes["database"]
+    schemaName := rs.Primary.Attributes["schema_name"]
+    sqlschema, err := connector.GetDatabaseSchema(database, schemaName)
+    if sqlschema != nil {
+      return fmt.Errorf("schema still exists")
+    }
+    if err != nil {
+      return fmt.Errorf("expected no error, got %s", err)
+    }
+  }
+  return nil
+}
+
+func testAccCheckSchemaExists(resource string, checks ...Check) resource.TestCheckFunc {
+  return func(state *terraform.State) error {
+    rs, ok := state.RootModule().Resources[resource]
+    if !ok {
+      return fmt.Errorf("not found: %s", resource)
+    }
+    if rs.Type != "mssql_database_schema" {
+      return fmt.Errorf("expected resource of type %s, got %s", "mssql_database_schema", rs.Type)
+    }
+    if rs.Primary.ID == "" {
+      return fmt.Errorf("no record ID is set")
+    }
+    connector, err := getTestConnector(rs.Primary.Attributes)
+    if err != nil {
+      return err
+    }
+    database := rs.Primary.Attributes["database"]
+    schemaName := rs.Primary.Attributes["schema_name"]
+    sqlschema, err := connector.GetDatabaseSchema(database, schemaName)
+    if err != nil {
+      return fmt.Errorf("error: %s", err)
+    }
+    if sqlschema.SchemaName != schemaName {
+      return fmt.Errorf("expected to be schema %s, got %s", schemaName, sqlschema.SchemaName)
+    }
+
+    var actual interface{}
+    for _, check := range checks {
+      switch check.name {
+      case "schema_name":
+        actual = sqlschema.SchemaName
+      case "owner_name":
+        actual = sqlschema.OwnerName
+      default:
+        return fmt.Errorf("unknown property %s", check.name)
+      }
+      if (check.op == "" || check.op == "==") && !equal(check.expected, actual) {
+        return fmt.Errorf("expected %s == %s, got %s", check.name, check.expected, actual)
+      }
+      if check.op == "!=" && equal(check.expected, actual) {
+        return fmt.Errorf("expected %s != %s, got %s", check.name, check.expected, actual)
+      }
+    }
+    return nil
+  }
+}

--- a/mssql/utils.go
+++ b/mssql/utils.go
@@ -38,6 +38,14 @@ func getDatabaseRoleID(data *schema.ResourceData) string {
   return fmt.Sprintf("sqlserver://%s:%s/%s/%s", host, port, database, roleName)
 }
 
+func getDatabaseSchemaID(data *schema.ResourceData) string {
+  host := data.Get(serverProp + ".0.host").(string)
+  port := data.Get(serverProp + ".0.port").(string)
+  database := data.Get(databaseProp).(string)
+  schemaName := data.Get(schemaNameProp).(string)
+  return fmt.Sprintf("sqlserver://%s:%s/%s/%s", host, port, database, schemaName)
+}
+
 func loggerFromMeta(meta interface{}, resource, function string) zerolog.Logger {
   return meta.(model.Provider).ResourceLogger(resource, function)
 }

--- a/sql/database_role.go
+++ b/sql/database_role.go
@@ -40,27 +40,13 @@ func (c *Connector) GetDatabaseRole(ctx context.Context, database, roleName stri
 
 func (c *Connector) CreateDatabaseRole(ctx context.Context, database, roleName string, ownerName string) error {
   cmd := `DECLARE @sql nvarchar(max);
-          IF @@VERSION LIKE 'Microsoft SQL Azure%' AND @database = 'master'
+          IF @ownerName = 'dbo' OR @ownerName = ''
             BEGIN
-              IF @ownerName = 'dbo' OR @ownerName = ''
-                BEGIN
-                  SET @sql = 'CREATE ROLE ' + QuoteName(@roleName)
-                END
-              ELSE
-                BEGIN
-                  SET @sql = 'CREATE ROLE ' + QuoteName(@roleName) + ' AUTHORIZATION ' + QuoteName(@ownerName)
-                END
+              SET @sql = 'CREATE ROLE ' + QuoteName(@roleName)
             END
-          IF @@VERSION NOT LIKE 'Microsoft SQL Azure%'
+          ELSE
             BEGIN
-              IF @ownerName = 'dbo' OR @ownerName = ''
-                BEGIN
-                  SET @sql = 'CREATE ROLE ' + QuoteName(@roleName)
-                END
-              ELSE
-                BEGIN
-                  SET @sql = 'CREATE ROLE ' + QuoteName(@roleName) + ' AUTHORIZATION ' + QuoteName(@ownerName)
-                END
+              SET @sql = 'CREATE ROLE ' + QuoteName(@roleName) + ' AUTHORIZATION ' + QuoteName(@ownerName)
             END
           EXEC (@sql);`
 

--- a/sql/database_schema.go
+++ b/sql/database_schema.go
@@ -1,0 +1,104 @@
+package sql
+
+import (
+  "context"
+  "database/sql"
+  "github.com/betr-io/terraform-provider-mssql/mssql/model"
+)
+
+func (c *Connector) GetDatabaseSchema(ctx context.Context, database, schemaName string) (*model.DatabaseSchema, error) {
+  cmd := `IF @@VERSION LIKE 'Microsoft SQL Azure%' AND @database = 'master'
+            BEGIN
+              IF @ownerName = 'dbo' OR @ownerName = ''
+                BEGIN
+                  SELECT dp1.schema_id, dp1.name, dp1.principal_id, '' AS name FROM [sys].[schemas] dp1 INNER JOIN [sys].[database_principals] dp2 ON dp1.principal_id = dp2.principal_id AND dp1.name = @schemaName
+                END
+            END
+          ELSE
+            BEGIN
+              SELECT dp1.schema_id, dp1.name, dp1.principal_id, dp2.name FROM [sys].[schemas] dp1 INNER JOIN [sys].[database_principals] dp2 ON dp1.principal_id = dp2.principal_id AND dp1.name = @schemaName
+            END`
+  var sqlschema model.DatabaseSchema
+  err := c.
+    setDatabase(&database).
+    QueryRowContext(ctx, cmd,
+      func(r *sql.Row) error {
+        return r.Scan(&sqlschema.SchemaID, &sqlschema.SchemaName, &sqlschema.OwnerId, &sqlschema.OwnerName)
+      },
+      sql.Named("database", database),
+      sql.Named("schemaName", schemaName),
+      sql.Named("ownerName", sqlschema.OwnerName),
+    )
+  if err != nil {
+    if err == sql.ErrNoRows {
+      return nil, nil
+    }
+    return nil, err
+  }
+  return &sqlschema, nil
+}
+
+func (c *Connector) CreateDatabaseSchema(ctx context.Context, database, schemaName string, ownerName string) error {
+  cmd := `DECLARE @sql nvarchar(max);
+          IF @ownerName = 'dbo' OR @ownerName = ''
+            BEGIN
+              SET @sql = 'CREATE SCHEMA ' + @schemaName
+            END
+          ELSE
+            BEGIN
+              SET @sql = 'CREATE SCHEMA ' + @schemaName + ' AUTHORIZATION ' + @ownerName
+            END
+          EXEC (@sql);`
+
+  return c.
+    setDatabase(&database).
+    ExecContext(ctx, cmd,
+      sql.Named("schemaName", schemaName),
+      sql.Named("ownerName", ownerName),
+      sql.Named("database", database),
+    )
+}
+
+func (c *Connector) DeleteDatabaseSchema(ctx context.Context, database, schemaName string) error {
+  cmd := `DECLARE @stmt nvarchar(max)
+          DECLARE @sql NVARCHAR(max)
+          DECLARE @user_name NVARCHAR(max) = (SELECT USER_NAME())
+          IF @@VERSION LIKE 'Microsoft SQL Azure%' AND @database = 'master'
+            BEGIN
+              SET @stmt = 'IF EXISTS (SELECT 1 FROM [sys].[schemas] WHERE [name] = ' + QuoteName(@schemaName, '''') + ') ' +
+                          'DROP SCHEMA ' + @schemaName
+            END
+          ELSE
+            BEGIN
+              SET @sql =  'IF EXISTS (SELECT 1 FROM [sys].[schemas] dp1 INNER JOIN [sys].[database_principals] dp2 ON dp1.principal_id = dp2.principal_id AND dp1.name = ' + QuoteName(@schemaName, '''') + ') ' +
+                          'ALTER AUTHORIZATION ON SCHEMA:: [' + @schemaName + '] TO [' + @user_name + ']'
+              EXEC sp_executesql @sql;
+              SET @stmt = 'IF EXISTS (SELECT 1 FROM [sys].[schemas] WHERE [name] = ' + QuoteName(@schemaName, '''') + ') ' +
+                          'DROP SCHEMA ' + @schemaName
+            END
+          EXEC (@stmt)`
+
+  return c.
+    setDatabase(&database).
+    ExecContext(ctx, cmd,
+      sql.Named("database", database),
+      sql.Named("schemaName", schemaName),
+    )
+}
+
+func (c *Connector) UpdateDatabaseSchema(ctx context.Context, database string, schemaName string, ownerName string) error {
+  cmd := `DECLARE @sql NVARCHAR(max)
+          IF @ownerName = 'dbo' OR @ownerName = ''
+            BEGIN
+              SET @ownerName = (SELECT USER_NAME())
+            END
+          SET @sql = 'ALTER AUTHORIZATION ON SCHEMA:: [' + @schemaName + '] TO [' + @ownerName + ']'
+          EXEC (@sql)`
+
+  return c.
+    setDatabase(&database).
+    ExecContext(ctx, cmd,
+      sql.Named("schemaName", schemaName),
+      sql.Named("ownerName", ownerName),
+    )
+}

--- a/sql/login.go
+++ b/sql/login.go
@@ -9,7 +9,7 @@ import (
 func (c *Connector) GetLogin(ctx context.Context, name string) (*model.Login, error) {
   var login model.Login
   err := c.QueryRowContext(ctx,
-    "SELECT principal_id, name, CONVERT(VARCHAR(1000), [sid], 1), default_database_name, default_language_name FROM [master].[sys].[sql_logins] WHERE [name] = @name",
+    "SELECT principal_id, name, CONVERT(VARCHAR(85), [sid], 1), default_database_name, default_language_name FROM [master].[sys].[sql_logins] WHERE [name] = @name",
     func(r *sql.Row) error {
       return r.Scan(&login.PrincipalID, &login.LoginName, &login.SIDStr, &login.DefaultDatabase, &login.DefaultLanguage)
     },
@@ -30,7 +30,7 @@ func (c *Connector) CreateLogin(ctx context.Context, name, password, sid, defaul
                      'WITH PASSWORD = ' + QuoteName(@password, '''')
           IF NOT @sid = ''
             BEGIN
-              SET @sql = @sql + ', SID = ' + CONVERT(VARCHAR(1000), @sid, 1)
+              SET @sql = @sql + ', SID = ' + CONVERT(VARCHAR(85), @sid, 1)
             END
           IF @@VERSION NOT LIKE 'Microsoft SQL Azure%'
             BEGIN

--- a/test-fixtures/all/providers.tf
+++ b/test-fixtures/all/providers.tf
@@ -1,6 +1,7 @@
 provider "azuread" {}
 
 provider "azurerm" {
+  subscription_id = "63649104-658d-4cc3-bdc4-1081787b21d4"
   features {}
 }
 

--- a/test-fixtures/all/terraform.tfvars
+++ b/test-fixtures/all/terraform.tfvars
@@ -1,6 +1,7 @@
-prefix    = "Betr"
-location  = "Norway East"
-tenant_id = "30ddf688-b59c-470c-b8e1-143ccbb6ce33"
+prefix    = "devts1"
+location  = "North Europe"
+tenant_id = "5e807663-b750-4b5e-9a65-4942b3bcc3d8"
+sql_servers_group = "SQLDirectoryReader"
 
-local_ip_addresses = ["193.214.250.243"]
+local_ip_addresses = ["34.254.37.70"]
 # local_ip_addresses = ["193.214.69.94"]


### PR DESCRIPTION
added acctest and few fixes

TESTARGS=-count=1 make testacc
if [ -f .local.env ]; then source .local.env; fi && TF_ACC=1 TERRAFORM_VERSION="~> 1.5" go test github.com/betr-io/terraform-provider-mssql/mssql -v -count=1 -timeout 120m
=== RUN   TestAccDataLogin_Local_Basic
--- PASS: TestAccDataLogin_Local_Basic (3.73s)
=== RUN   TestAccDataLogin_Azure_Basic
--- PASS: TestAccDataLogin_Azure_Basic (13.17s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccDatabasePermissions_Local_BasicImport
--- PASS: TestAccDatabasePermissions_Local_BasicImport (4.19s)
=== RUN   TestAccDatabasePermissions_Local_Basic
--- PASS: TestAccDatabasePermissions_Local_Basic (3.44s)
=== RUN   TestAccDatabasePermissions_Azure_Basic
--- PASS: TestAccDatabasePermissions_Azure_Basic (11.94s)
=== RUN   TestAccRole_Local_BasicImport
--- PASS: TestAccRole_Local_BasicImport (3.05s)
=== RUN   TestAccRole_Local_Basic_Create
--- PASS: TestAccRole_Local_Basic_Create (2.27s)
=== RUN   TestAccRole_Local_Basic_Create_owner
--- PASS: TestAccRole_Local_Basic_Create_owner (3.79s)
=== RUN   TestAccRole_Azure_Basic_Create
--- PASS: TestAccRole_Azure_Basic_Create (7.31s)
=== RUN   TestAccRole_Azure_Basic_Create_owner
--- PASS: TestAccRole_Azure_Basic_Create_owner (12.17s)
=== RUN   TestAccRole_Local_Basic_Update
--- PASS: TestAccRole_Local_Basic_Update (4.21s)
=== RUN   TestAccRole_Local_Basic_Update_owner
--- PASS: TestAccRole_Local_Basic_Update_owner (7.37s)
=== RUN   TestAccRole_Local_Basic_Update_remove_owner
--- PASS: TestAccRole_Local_Basic_Update_remove_owner (6.30s)
=== RUN   TestAccRole_Local_Basic_Update_role_and_owner
--- PASS: TestAccRole_Local_Basic_Update_role_and_owner (7.37s)
=== RUN   TestAccRole_Azure_Basic_Update
--- PASS: TestAccRole_Azure_Basic_Update (19.08s)
=== RUN   TestAccRole_Azure_Basic_Update_owner
--- PASS: TestAccRole_Azure_Basic_Update_owner (22.31s)
=== RUN   TestAccSchema_Local_BasicImport
--- PASS: TestAccSchema_Local_BasicImport (3.05s)
=== RUN   TestAccSchema_Local_Basic_Create
--- PASS: TestAccSchema_Local_Basic_Create (2.26s)
=== RUN   TestAccSchema_Local_Basic_Create_owner
--- PASS: TestAccSchema_Local_Basic_Create_owner (3.75s)
=== RUN   TestAccSchema_Azure_Basic_Create
--- PASS: TestAccSchema_Azure_Basic_Create (7.08s)
=== RUN   TestAccSchema_Azure_Basic_Create_owner
--- PASS: TestAccSchema_Azure_Basic_Create_owner (12.40s)
=== RUN   TestAccSchema_Local_Basic_Update_owner
--- PASS: TestAccSchema_Local_Basic_Update_owner (7.51s)
=== RUN   TestAccSchema_Local_Basic_Update_remove_owner
--- PASS: TestAccSchema_Local_Basic_Update_remove_owner (6.29s)
=== RUN   TestAccSchema_Azure_Basic_Update_owner
--- PASS: TestAccSchema_Azure_Basic_Update_owner (20.35s)
=== RUN   TestAccLogin_Local_BasicImport
--- PASS: TestAccLogin_Local_BasicImport (3.35s)
=== RUN   TestAccLogin_Local_Basic
--- PASS: TestAccLogin_Local_Basic (2.89s)
=== RUN   TestAccLogin_Local_Basic_SID
--- PASS: TestAccLogin_Local_Basic_SID (2.89s)
=== RUN   TestAccLogin_Azure_Basic
--- PASS: TestAccLogin_Azure_Basic (7.87s)
=== RUN   TestAccLogin_Azure_Basic_SID
--- PASS: TestAccLogin_Azure_Basic_SID (7.97s)
=== RUN   TestAccLogin_Local_UpdateLoginName
--- PASS: TestAccLogin_Local_UpdateLoginName (5.59s)
=== RUN   TestAccLogin_Local_UpdatePassword
--- PASS: TestAccLogin_Local_UpdatePassword (5.00s)
=== RUN   TestAccLogin_Local_UpdateDefaultDatabase
--- PASS: TestAccLogin_Local_UpdateDefaultDatabase (4.91s)
=== RUN   TestAccLogin_Local_UpdateDefaultLanguage
--- PASS: TestAccLogin_Local_UpdateDefaultLanguage (4.93s)
=== RUN   TestAccLogin_Azure_UpdateLoginName
--- PASS: TestAccLogin_Azure_UpdateLoginName (15.60s)
=== RUN   TestAccLogin_Azure_UpdatePassword
--- PASS: TestAccLogin_Azure_UpdatePassword (18.62s)
=== RUN   TestAccUser_Local_BasicImport
--- PASS: TestAccUser_Local_BasicImport (3.56s)
=== RUN   TestAccUser_Local_Instance
--- PASS: TestAccUser_Local_Instance (3.15s)
=== RUN   TestAccMultipleUsers_Local_Instance
--- PASS: TestAccMultipleUsers_Local_Instance (5.78s)
=== RUN   TestAccUser_Azure_Instance
--- PASS: TestAccUser_Azure_Instance (13.65s)
=== RUN   TestAccUser_Azure_Database
--- PASS: TestAccUser_Azure_Database (9.30s)
=== RUN   TestAccUser_AzureadChain_Database
--- PASS: TestAccUser_AzureadChain_Database (12.54s)
=== RUN   TestAccUser_AzureadMSI_Database
--- PASS: TestAccUser_AzureadMSI_Database (17.04s)
=== RUN   TestAccUser_Azure_External
--- PASS: TestAccUser_Azure_External (8.73s)
=== RUN   TestAccUser_AzureadChain_External
--- PASS: TestAccUser_AzureadChain_External (10.93s)
=== RUN   TestAccUser_AzureadMSI_External
--- PASS: TestAccUser_AzureadMSI_External (11.18s)
=== RUN   TestAccUser_Local_Update_DefaultSchema
--- PASS: TestAccUser_Local_Update_DefaultSchema (5.33s)
=== RUN   TestAccUser_Local_Update_DefaultLanguage
--- PASS: TestAccUser_Local_Update_DefaultLanguage (4.66s)
=== RUN   TestAccUser_Local_Update_Roles
--- PASS: TestAccUser_Local_Update_Roles (9.02s)
=== RUN   TestAccUser_Azure_Update_DefaultSchema
--- PASS: TestAccUser_Azure_Update_DefaultSchema (29.66s)
=== RUN   TestAccUser_Azure_Update_DefaultLanguage
--- PASS: TestAccUser_Azure_Update_DefaultLanguage (20.94s)
=== RUN   TestAccUser_Azure_Update_Roles
--- PASS: TestAccUser_Azure_Update_Roles (35.39s)
PASS
ok      github.com/betr-io/terraform-provider-mssql/mssql       474.859s