### PR TITLE
new datasource database_credential

### DIFF
--- a/docs/data-sources/database_credential.md
+++ b/docs/data-sources/database_credential.md
@@ -1,11 +1,11 @@
-# mssql_database_role (Data Source)
+# mssql_database_credential (Data Source)
 
-The `mssql_database_role` obtains information about database role.
+The `mssql_database_credential` obtains information about user permissions on a SQL Server.
 
 ## Example Usage
 
 ```hcl
-data "mssql_database_role" "example" {
+data "mssql_database_credential" "example" {
   server {
     host = "example-sql-server.database.windows.net"
     azure_login {
@@ -14,8 +14,8 @@ data "mssql_database_role" "example" {
       client_secret = "xxxxxxxxxxxxxxxxxxxxxx"
     }
   }
-  database  = "master"
-  role_name = "example-role-name"
+  database  = "example"
+  credential_name = "example-credential-name"
 }
 ```
 
@@ -24,8 +24,8 @@ data "mssql_database_role" "example" {
 The following arguments are supported:
 
 * `server` - (Required) Server and login details for the SQL Server. The attributes supported in the `server` block is detailed below.
-* `database` - (Optional) The database. Defaults to `master`.
-* `role_name` - (Required) The name of the role.
+* `database` - (Required) The database.
+* `credential_name` - (Required) The database scoped credential name.
 
 The `server` block supports the following arguments:
 
@@ -43,6 +43,7 @@ The `login` block supports the following arguments:
 
 The following attributes are exported:
 
-* `principal_id` - The principal id of this database role.
-* `owner_name` - The database user name or role name that is own the role.
-* `owning_principal_id` - The database user id or the role id that is own the role.
+* `principal_id` - The principal id of this database scoped credential.
+* `credential_id` - The id of this database scoped credential.
+* `credential_name` - The name of the database scoped credential.
+* `identity_name` - The name of the account.

--- a/docs/data-sources/database_schema.md
+++ b/docs/data-sources/database_schema.md
@@ -24,8 +24,8 @@ data "mssql_database_schema" "example" {
 The following arguments are supported:
 
 * `server` - (Required) Server and login details for the SQL Server. The attributes supported in the `server` block is detailed below.
-* `schema_name` - (Required) The name of the schema.
 * `database` - (Optional) The database. Defaults to `master`.
+* `schema_name` - (Required) The name of the schema.
 
 The `server` block supports the following arguments:
 

--- a/docs/resources/database_credential.md
+++ b/docs/resources/database_credential.md
@@ -69,7 +69,7 @@ Before importing `mssql_database_credential`, you must to configure the authenti
 1. Using Azure AD authentication, you must set the following environment variables: `MSSQL_TENANT_ID`, `MSSQL_CLIENT_ID` and `MSSQL_CLIENT_SECRET`.
 2. Using SQL authentication, you must set the following environment variables: `MSSQL_USERNAME` and `MSSQL_PASSWORD`.
 
-After that you can import the MSSQL Database permissions using the server URL and `principal ID of the user`, e.g.
+After that you can import the SQL Server database scoped credential using the server URL and `credential name`, e.g.
 
 ```shell
 terraform import mssql_database_credential.example 'mssql://example-sql-server.database.windows.net/example-db/credential_name'

--- a/docs/resources/database_permissions.md
+++ b/docs/resources/database_permissions.md
@@ -62,7 +62,7 @@ Before importing `mssql_database_permissions`, you must to configure the authent
 1. Using Azure AD authentication, you must set the following environment variables: `MSSQL_TENANT_ID`, `MSSQL_CLIENT_ID` and `MSSQL_CLIENT_SECRET`.
 2. Using SQL authentication, you must set the following environment variables: `MSSQL_USERNAME` and `MSSQL_PASSWORD`.
 
-After that you can import the MSSQL Database permissions using the server URL and `principal ID of the user`, e.g.
+After that you can import the SQL Server database permission using the server URL and `user name`, e.g.
 
 ```shell
 terraform import mssql_database_permissions.example 'mssql://example-sql-server.database.windows.net/master/username/permissions'

--- a/mssql/datasource_database_credential.go
+++ b/mssql/datasource_database_credential.go
@@ -1,0 +1,87 @@
+package mssql
+
+import (
+  "context"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+  "github.com/pkg/errors"
+)
+func datasourceDatabaseCredential() *schema.Resource {
+  return &schema.Resource{
+    ReadContext:   datasourceDatabaseCredentialRead,
+    Schema: map[string]*schema.Schema{
+      serverProp: {
+        Type:     schema.TypeList,
+        MaxItems: 1,
+        Required: true,
+        ForceNew: true,
+        Elem: &schema.Resource{
+          Schema: getServerSchema(serverProp),
+        },
+      },
+      databaseProp: {
+        Type:     schema.TypeString,
+        Required: true,
+        ForceNew: true,
+      },
+      credentialNameProp: {
+        Type:     schema.TypeString,
+        Required: true,
+        ForceNew: true,
+      },
+      identitynameProp: {
+        Type:     schema.TypeString,
+        Computed: true,
+      },
+      principalIdProp: {
+        Type:     schema.TypeInt,
+        Computed: true,
+      },
+      credentialIdProp: {
+        Type:     schema.TypeInt,
+        Computed: true,
+      },
+    },
+    Timeouts: &schema.ResourceTimeout{
+      Default: defaultTimeout,
+    },
+  }
+}
+
+func datasourceDatabaseCredentialRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+  logger := loggerFromMeta(meta, "databasecredential", "read")
+  logger.Debug().Msgf("Read %s", data.Id())
+
+  database := data.Get(databaseProp).(string)
+  credentialname := data.Get(credentialNameProp).(string)
+
+  connector, err := getDatabaseCredentialConnector(meta, data)
+  if err != nil {
+    return diag.FromErr(err)
+  }
+
+  scopedcredential, err := connector.GetDatabaseCredential(ctx, database, credentialname)
+  if err != nil {
+    return diag.FromErr(errors.Wrapf(err, "unable to read database scoped credential [%s] on database [%s]", credentialname, database))
+  }
+  if scopedcredential == nil {
+    logger.Info().Msgf("No database scoped credential [%s] found on database [%s]", credentialname, database)
+    data.SetId("")
+  } else {
+    if err = data.Set(credentialNameProp, scopedcredential.CredentialName); err != nil {
+      return diag.FromErr(err)
+    }
+    if err = data.Set(identitynameProp, scopedcredential.IdentityName); err != nil {
+      return diag.FromErr(err)
+    }
+    if err = data.Set(principalIdProp, scopedcredential.PrincipalID); err != nil {
+      return diag.FromErr(err)
+    }
+    if err = data.Set(credentialIdProp, scopedcredential.CredentialID); err != nil {
+      return diag.FromErr(err)
+    }
+    data.SetId(getDatabaseCredentialID(data))
+  }
+
+  return nil
+}

--- a/mssql/datasource_database_credential_test.go
+++ b/mssql/datasource_database_credential_test.go
@@ -1,0 +1,109 @@
+package mssql
+
+import (
+  "fmt"
+  "os"
+  "testing"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataDatabaseCredential_Azure_Basic(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckDataCredentialDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckDataCredential(t, "data_azure_test", "azure", map[string]interface{}{"database": "testdb", "credential_name": "test_scoped_data_cred", "identity_name": "test_identity_data_name", "secret": "V3ryS3cretP@asswd", "password": "V3ryS3cretP@asswd!Key"}),
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "id", "sqlserver://"+os.Getenv("TF_ACC_SQL_SERVER")+":1433/testdb/test_scoped_data_cred"),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "database", "testdb"),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "credential_name", "test_scoped_data_cred"),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.#", "1"),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.0.host", os.Getenv("TF_ACC_SQL_SERVER")),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.0.port", "1433"),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.0.azure_login.#", "1"),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.0.azure_login.0.tenant_id", os.Getenv("MSSQL_TENANT_ID")),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.0.azure_login.0.client_id", os.Getenv("MSSQL_CLIENT_ID")),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.0.azure_login.0.client_secret", os.Getenv("MSSQL_CLIENT_SECRET")),
+          resource.TestCheckResourceAttr("data.mssql_database_credential.data_azure_test", "server.0.login.#", "0"),
+          resource.TestCheckResourceAttrSet("data.mssql_database_credential.data_azure_test", "principal_id"),
+          resource.TestCheckResourceAttrSet("data.mssql_database_credential.data_azure_test", "credential_id"),
+        ),
+      },
+    },
+  })
+}
+
+func testAccCheckDataCredential(t *testing.T, name string, login string, data map[string]interface{}) string {
+  text := `resource "mssql_database_masterkey" "{{ .name }}" {
+             server {
+               host = "{{ .host }}"
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+             }
+             database = "{{ .database }}"
+             password = "{{ .password }}"
+           }
+           resource "mssql_database_credential" "{{ .name }}" {
+             server {
+               host = "{{ .host }}"
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+             }
+             database = "{{ .database }}"
+             credential_name = "{{ .credential_name }}"
+             identity_name = "{{ .identity_name }}"
+             {{ with .secret }}secret = "{{ . }}"{{ end }}
+             depends_on = [mssql_database_masterkey.{{ .name }}]
+            }
+           data "mssql_database_credential" "{{ .name }}" {
+             server {
+               host = "{{ .host }}"
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+             }
+             database = "{{ .database }}"
+             credential_name = "{{ .credential_name }}"
+             depends_on = [mssql_database_credential.{{ .name }}]
+           }`
+
+  data["name"] = name
+  data["login"] = login
+  if login == "fedauth" || login == "msi" || login == "azure" {
+    data["host"] = os.Getenv("TF_ACC_SQL_SERVER")
+  } else if login == "login" {
+    data["host"] = "localhost"
+  } else {
+    t.Fatalf("login expected to be one of 'login', 'azure', 'msi', 'fedauth', got %s", login)
+  }
+  res, err := templateToString(name, text, data)
+  if err != nil {
+    t.Fatalf("%s", err)
+  }
+  return res
+}
+
+func testAccCheckDataCredentialDestroy(state *terraform.State) error {
+  for _, rs := range state.RootModule().Resources {
+    if rs.Type != "mssql_database_credential" {
+      continue
+    }
+    if rs.Type != "mssql_database_masterkey" {
+      continue
+    }
+    connector, err := getTestConnector(rs.Primary.Attributes)
+    if err != nil {
+      return err
+    }
+
+    database := rs.Primary.Attributes["database"]
+    credentialName := rs.Primary.Attributes["credential_name"]
+    scopedcredential, err := connector.GetDatabaseCredential(database, credentialName)
+    if scopedcredential != nil {
+      return fmt.Errorf("scoped credential still exists")
+    }
+    if err != nil {
+      return fmt.Errorf("expected no error, got %s", err)
+    }
+  }
+  return nil
+}

--- a/mssql/datasource_database_permissions.go
+++ b/mssql/datasource_database_permissions.go
@@ -47,6 +47,7 @@ func dataSourceDatabasePermissions() *schema.Resource {
     },
   }
 }
+
 func dataSourceDatabasePermissionsRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
   logger := loggerFromMeta(meta, "databasepermissions", "read")
   logger.Debug().Msgf("Read %s", getDatabasePermissionsID(data))

--- a/mssql/datasource_database_role.go
+++ b/mssql/datasource_database_role.go
@@ -48,6 +48,7 @@ func dataSourceDatabaseRole() *schema.Resource {
     },
   }
 }
+
 func dataSourceDatabaseRoleRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
   logger := loggerFromMeta(meta, "role", "read")
   logger.Debug().Msgf("Read %s", getDatabaseRoleID(data))
@@ -83,8 +84,6 @@ func dataSourceDatabaseRoleRead(ctx context.Context, data *schema.ResourceData, 
     }
     data.SetId(getDatabaseRoleID(data))
   }
-
-  logger.Info().Msgf("read role [%s].[%s]", database, roleName)
 
   return nil
 }

--- a/mssql/datasource_database_schema.go
+++ b/mssql/datasource_database_schema.go
@@ -48,6 +48,7 @@ func dataSourceDatabaseSchema() *schema.Resource {
     },
   }
 }
+
 func dataSourceDatabaseSchemaRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
   logger := loggerFromMeta(meta, "schema", "read")
   logger.Debug().Msgf("Read %s", getDatabaseSchemaID(data))
@@ -83,8 +84,6 @@ func dataSourceDatabaseSchemaRead(ctx context.Context, data *schema.ResourceData
     }
     data.SetId(getDatabaseSchemaID(data))
   }
-
-  logger.Info().Msgf("read role [%s].[%s]", database, schemaName)
 
   return nil
 }

--- a/mssql/provider.go
+++ b/mssql/provider.go
@@ -58,6 +58,7 @@ func Provider(factory model.ConnectorFactory) *schema.Provider {
       "mssql_database_permissions": dataSourceDatabasePermissions(),
       "mssql_database_role": dataSourceDatabaseRole(),
       "mssql_database_schema": dataSourceDatabaseSchema(),
+      "mssql_database_credential": datasourceDatabaseCredential(),
     },
     ConfigureContextFunc: func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
       return providerConfigure(ctx, data, factory)


### PR DESCRIPTION
if [ -f .local.env ]; then source .local.env; fi && TF_ACC=1 TERRAFORM_VERSION="~> 1.5" go test github.com/betr-io/terraform-provider-mssql/mssql -v -count=1 -timeout 120m
=== RUN   TestAccDataDatabaseCredential_Azure_Basic
--- PASS: TestAccDataDatabaseCredential_Azure_Basic (16.09s)
=== RUN   TestAccDataDatabasePermissions_Local_Basic
--- PASS: TestAccDataDatabasePermissions_Local_Basic (4.68s)
=== RUN   TestAccDataDatabaseRole_Local_Basic
--- PASS: TestAccDataDatabaseRole_Local_Basic (3.52s)
=== RUN   TestAccDataDatabaseRole_Azure_Basic
--- PASS: TestAccDataDatabaseRole_Azure_Basic (17.55s)
=== RUN   TestAccDataDatabaseSchema_Local_Basic
--- PASS: TestAccDataDatabaseSchema_Local_Basic (3.48s)
=== RUN   TestAccDataDatabaseSchema_Azure_Basic
--- PASS: TestAccDataDatabaseSchema_Azure_Basic (12.66s)
=== RUN   TestAccDataLogin_Local_Basic
--- PASS: TestAccDataLogin_Local_Basic (3.77s)
=== RUN   TestAccDataLogin_Azure_Basic
--- PASS: TestAccDataLogin_Azure_Basic (13.56s)
=== RUN   TestAccDataUser_Local_Basic
--- PASS: TestAccDataUser_Local_Basic (4.10s)
=== RUN   TestAccDataUser_Azure_Basic
--- PASS: TestAccDataUser_Azure_Basic (21.73s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccDatabaseCredential_Azure_BasicImport
--- PASS: TestAccDatabaseCredential_Azure_BasicImport (14.71s)
=== RUN   TestAccDatabaseCredential_Azure_Basic
--- PASS: TestAccDatabaseCredential_Azure_Basic (11.77s)
=== RUN   TestAccDatabaseCredential_Azure_Basic_update
--- PASS: TestAccDatabaseCredential_Azure_Basic_update (25.79s)
=== RUN   TestAccDatabaseMasterkey_Local_Basic
--- PASS: TestAccDatabaseMasterkey_Local_Basic (2.39s)
=== RUN   TestAccDatabaseMasterkey_Local_Basic_update
--- PASS: TestAccDatabaseMasterkey_Local_Basic_update (4.28s)
=== RUN   TestAccDatabasePermissions_Local_BasicImport
--- PASS: TestAccDatabasePermissions_Local_BasicImport (4.43s)
=== RUN   TestAccDatabasePermissions_Local_Basic
--- PASS: TestAccDatabasePermissions_Local_Basic (3.49s)
=== RUN   TestAccDatabasePermissions_Local_Basic_update_1
--- PASS: TestAccDatabasePermissions_Local_Basic_update_1 (6.31s)
=== RUN   TestAccDatabasePermissions_Local_Basic_update_2
--- PASS: TestAccDatabasePermissions_Local_Basic_update_2 (6.13s)
=== RUN   TestAccDatabasePermissions_Azure_Basic
--- PASS: TestAccDatabasePermissions_Azure_Basic (13.84s)
=== RUN   TestAccDatabaseRole_Local_BasicImport
--- PASS: TestAccDatabaseRole_Local_BasicImport (3.12s)
=== RUN   TestAccDatabaseRole_Local_Basic_Create
--- PASS: TestAccDatabaseRole_Local_Basic_Create (2.28s)
=== RUN   TestAccDatabaseRole_Local_Basic_Create_owner
--- PASS: TestAccDatabaseRole_Local_Basic_Create_owner (3.83s)
=== RUN   TestAccDatabaseRole_Azure_Basic_Create
--- PASS: TestAccDatabaseRole_Azure_Basic_Create (7.70s)
=== RUN   TestAccDatabaseRole_Azure_Basic_Create_owner
--- PASS: TestAccDatabaseRole_Azure_Basic_Create_owner (13.80s)
=== RUN   TestAccDatabaseRole_Local_Basic_Update
--- PASS: TestAccDatabaseRole_Local_Basic_Update (4.27s)
=== RUN   TestAccDatabaseRole_Local_Basic_Update_owner
--- PASS: TestAccDatabaseRole_Local_Basic_Update_owner (7.71s)
=== RUN   TestAccDatabaseRole_Local_Basic_Remove_owner
--- PASS: TestAccDatabaseRole_Local_Basic_Remove_owner (6.39s)
=== RUN   TestAccDatabaseRole_Local_Basic_Update_role_and_owner
--- PASS: TestAccDatabaseRole_Local_Basic_Update_role_and_owner (7.79s)
=== RUN   TestAccDatabaseRole_Azure_Basic_Update
--- PASS: TestAccDatabaseRole_Azure_Basic_Update (13.79s)
=== RUN   TestAccDatabaseRole_Azure_Basic_Update_owner
--- PASS: TestAccDatabaseRole_Azure_Basic_Update_owner (21.25s)
=== RUN   TestAccDatabaseSchema_Local_BasicImport
--- PASS: TestAccDatabaseSchema_Local_BasicImport (3.10s)
=== RUN   TestAccDatabaseSchema_Local_Basic_Create
--- PASS: TestAccDatabaseSchema_Local_Basic_Create (2.41s)
=== RUN   TestAccDatabaseSchema_Local_Basic_Create_owner
--- PASS: TestAccDatabaseSchema_Local_Basic_Create_owner (3.89s)
=== RUN   TestAccDatabaseSchema_Azure_Basic_Create
--- PASS: TestAccDatabaseSchema_Azure_Basic_Create (7.74s)
=== RUN   TestAccDatabaseSchema_Azure_Basic_Create_owner
--- PASS: TestAccDatabaseSchema_Azure_Basic_Create_owner (15.13s)
=== RUN   TestAccDatabaseSchema_Local_Basic_Update_owner
--- PASS: TestAccDatabaseSchema_Local_Basic_Update_owner (7.76s)
=== RUN   TestAccDatabaseSchema_Local_Basic_Update_remove_owner
--- PASS: TestAccDatabaseSchema_Local_Basic_Update_remove_owner (6.33s)
=== RUN   TestAccDatabaseSchema_Azure_Basic_Update_owner
--- PASS: TestAccDatabaseSchema_Azure_Basic_Update_owner (21.36s)
=== RUN   TestAccLogin_Local_BasicImport
--- PASS: TestAccLogin_Local_BasicImport (3.28s)
=== RUN   TestAccLogin_Local_Basic
--- PASS: TestAccLogin_Local_Basic (2.88s)
=== RUN   TestAccLogin_Local_Basic_SID
--- PASS: TestAccLogin_Local_Basic_SID (2.99s)
=== RUN   TestAccLogin_Azure_Basic
--- PASS: TestAccLogin_Azure_Basic (8.29s)
=== RUN   TestAccLogin_Azure_Basic_SID
--- PASS: TestAccLogin_Azure_Basic_SID (8.47s)
=== RUN   TestAccLogin_Local_UpdateLoginName
--- PASS: TestAccLogin_Local_UpdateLoginName (5.68s)
=== RUN   TestAccLogin_Local_UpdatePassword
--- PASS: TestAccLogin_Local_UpdatePassword (5.18s)
=== RUN   TestAccLogin_Local_UpdateDefaultDatabase
--- PASS: TestAccLogin_Local_UpdateDefaultDatabase (5.16s)
=== RUN   TestAccLogin_Local_UpdateDefaultLanguage
--- PASS: TestAccLogin_Local_UpdateDefaultLanguage (4.98s)
=== RUN   TestAccLogin_Azure_UpdateLoginName
--- PASS: TestAccLogin_Azure_UpdateLoginName (16.69s)
=== RUN   TestAccLogin_Azure_UpdatePassword
--- PASS: TestAccLogin_Azure_UpdatePassword (14.13s)
=== RUN   TestAccUser_Local_BasicImport
--- PASS: TestAccUser_Local_BasicImport (3.76s)
=== RUN   TestAccUser_Local_Instance
--- PASS: TestAccUser_Local_Instance (3.11s)
=== RUN   TestAccMultipleUsers_Local_Instance
--- PASS: TestAccMultipleUsers_Local_Instance (6.05s)
=== RUN   TestAccUser_Azure_Instance
--- PASS: TestAccUser_Azure_Instance (14.19s)
=== RUN   TestAccUser_Azure_Database
--- PASS: TestAccUser_Azure_Database (12.38s)
=== RUN   TestAccUser_AzureadChain_Database
--- PASS: TestAccUser_AzureadChain_Database (12.80s)
=== RUN   TestAccUser_AzureadMSI_Database
--- PASS: TestAccUser_AzureadMSI_Database (12.23s)
=== RUN   TestAccUser_Azure_External
--- PASS: TestAccUser_Azure_External (11.49s)
=== RUN   TestAccUser_AzureadChain_External
--- PASS: TestAccUser_AzureadChain_External (11.30s)
=== RUN   TestAccUser_AzureadMSI_External
--- PASS: TestAccUser_AzureadMSI_External (11.06s)
=== RUN   TestAccUser_Local_Update_DefaultSchema
--- PASS: TestAccUser_Local_Update_DefaultSchema (5.41s)
=== RUN   TestAccUser_Local_Update_DefaultLanguage
--- PASS: TestAccUser_Local_Update_DefaultLanguage (4.76s)
=== RUN   TestAccUser_Local_Update_Roles
--- PASS: TestAccUser_Local_Update_Roles (9.36s)
=== RUN   TestAccUser_Azure_Update_DefaultSchema
--- PASS: TestAccUser_Azure_Update_DefaultSchema (26.18s)
=== RUN   TestAccUser_Azure_Update_DefaultLanguage
--- PASS: TestAccUser_Azure_Update_DefaultLanguage (21.69s)
=== RUN   TestAccUser_Azure_Update_Roles
--- PASS: TestAccUser_Azure_Update_Roles (41.80s)
PASS
ok      github.com/betr-io/terraform-provider-mssql/mssql       639.228s
