### PR TITLE
fix: Add missing oidc documentation for other resources and data

### DIFF
--- a/docs/data-sources/azure_external_datasource.md
+++ b/docs/data-sources/azure_external_datasource.md
@@ -35,7 +35,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -48,6 +48,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/data-sources/database_credential.md
+++ b/docs/data-sources/database_credential.md
@@ -33,7 +33,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -46,6 +46,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/data-sources/database_permissions.md
+++ b/docs/data-sources/database_permissions.md
@@ -33,7 +33,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -46,6 +46,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/data-sources/database_role.md
+++ b/docs/data-sources/database_role.md
@@ -33,7 +33,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -46,6 +46,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/data-sources/database_schema.md
+++ b/docs/data-sources/database_schema.md
@@ -33,7 +33,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -46,6 +46,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/data-sources/entraid_login.md
+++ b/docs/data-sources/entraid_login.md
@@ -31,7 +31,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -44,6 +44,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/data-sources/login.md
+++ b/docs/data-sources/login.md
@@ -30,7 +30,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -43,6 +43,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -32,7 +32,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -45,6 +45,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/azure_external_datasource.md
+++ b/docs/resources/azure_external_datasource.md
@@ -67,7 +67,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -80,6 +80,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/database_credential.md
+++ b/docs/resources/database_credential.md
@@ -47,7 +47,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -60,6 +60,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/database_masterkey.md
+++ b/docs/resources/database_masterkey.md
@@ -29,7 +29,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -42,6 +42,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/database_permissions.md
+++ b/docs/resources/database_permissions.md
@@ -35,7 +35,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -48,6 +48,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/database_role.md
+++ b/docs/resources/database_role.md
@@ -54,7 +54,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -67,6 +67,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/database_schema.md
+++ b/docs/resources/database_schema.md
@@ -54,7 +54,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -67,6 +67,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/database_sqlscript.md
+++ b/docs/resources/database_sqlscript.md
@@ -65,7 +65,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -78,6 +78,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/entraid_login.md
+++ b/docs/resources/entraid_login.md
@@ -32,7 +32,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -45,6 +45,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 

--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -31,7 +31,7 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
-* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
 * `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
@@ -44,6 +44,19 @@ The `azure_login` block supports the following arguments:
 * `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
 
 The `azuread_managed_identity_auth` block supports the following arguments:
 


### PR DESCRIPTION
Adding the OIDC documentation to all the resources and data providers doc.