### PR TITLE
add database resource type

### DIFF
--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -1,0 +1,91 @@
+# mssql_database (Data Source)
+
+The `mssql_database` data source obtains information about an existing database on a SQL Server instance.
+
+## Example Usage
+
+```hcl
+data "mssql_database" "example" {
+  server {
+    host = "localhost"
+    login {
+      username = "sa"
+      password = "MySuperSecr3t!"
+    }
+  }
+  name = "example-db"
+}
+
+output "collation" {
+  value = data.mssql_database.example.collation
+}
+```
+
+### Using an RDS SQL Server endpoint
+
+```hcl
+data "mssql_database" "example" {
+  server {
+    host = "myinstance.xxxxxxxxxx.us-east-1.rds.amazonaws.com"
+    port = "1433"
+    login {
+      username = var.mssql_username
+      password = var.mssql_password
+    }
+  }
+  name = "example-db"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `server` - (Required) Server and login details for the SQL Server. The attributes supported in the `server` block is detailed below.
+* `name` - (Required) The name of the database to look up.
+
+The `server` block supports the following arguments:
+
+* `host` - (Required) The host of the SQL Server. Changing this forces a new resource to be created.
+* `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
+* `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
+* `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
+* `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
+
+The `login` block supports the following arguments:
+
+* `username` - (Required) The username of the SQL Server login. Can also be sourced from the `MSSQL_USERNAME` environment variable.
+* `password` - (Required) The password of the SQL Server login. Can also be sourced from the `MSSQL_PASSWORD` environment variable.
+
+The `azure_login` block supports the following arguments:
+
+* `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
+* `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
+* `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
+
+The `azuread_managed_identity_auth` block supports the following arguments:
+
+* `user_id` - (Optional) Id of a user-assigned managed identity to assume. Omitting this property instructs the provider to assume a system-assigned managed identity.
+
+-> Only one of `login`, `azure_login`, `azuread_default_chain_auth` and `azuread_managed_identity_auth` can be specified.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `database_id` - The internal numeric ID of the database in `sys.databases`.
+* `collation` - The collation of the database, e.g. `SQL_Latin1_General_CP1_CI_AS`.

--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -2,6 +2,12 @@
 
 The `mssql_database` data source obtains information about an existing database on a SQL Server instance.
 
+## Compatibility
+
+This data source reads from `sys.databases` and works across all SQL Server variants: AWS RDS SQL Server, Azure SQL Managed Instance, Azure SQL Database, and on-premises SQL Server.
+
+Note: if you manage your Azure SQL Database databases via `azurerm_mssql_database`, you can still use this data source to read their properties (e.g. collation, database ID) for use in other resources.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -1,0 +1,116 @@
+# mssql_database
+
+The `mssql_database` resource allows you to create and manage databases on a SQL Server instance.
+
+## Example Usage
+
+### Basic usage
+
+```hcl
+resource "mssql_database" "example" {
+  server {
+    host = "localhost"
+    login {
+      username = "sa"
+      password = "MySuperSecr3t!"
+    }
+  }
+  name = "example-db"
+}
+```
+
+### With explicit collation
+
+```hcl
+resource "mssql_database" "example" {
+  server {
+    host = "localhost"
+    login {
+      username = "sa"
+      password = "MySuperSecr3t!"
+    }
+  }
+  name      = "example-db"
+  collation = "SQL_Latin1_General_CP1_CI_AS"
+}
+```
+
+### Using an RDS SQL Server endpoint
+
+```hcl
+resource "mssql_database" "example" {
+  server {
+    host = "myinstance.xxxxxxxxxx.us-east-1.rds.amazonaws.com"
+    port = "1433"
+    login {
+      username = var.mssql_username
+      password = var.mssql_password
+    }
+  }
+  name = "example-db"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `server` - (Required) Server and login details for the SQL Server. The attributes supported in the `server` block is detailed below.
+* `name` - (Required) The name of the database. Changing this forces a new resource to be created.
+* `collation` - (Optional) The collation of the database, e.g. `SQL_Latin1_General_CP1_CI_AS`. If not specified, the server's default collation is used. Changing this resource property modifies the existing resource.
+
+The `server` block supports the following arguments:
+
+* `host` - (Required) The host of the SQL Server. Changing this forces a new resource to be created.
+* `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
+* `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
+* `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). The attributes supported in the `azuread_default_chain_auth` block are detailed below.
+* `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
+
+The `login` block supports the following arguments:
+
+* `username` - (Required) The username of the SQL Server login. Can also be sourced from the `MSSQL_USERNAME` environment variable.
+* `password` - (Required) The password of the SQL Server login. Can also be sourced from the `MSSQL_PASSWORD` environment variable.
+
+The `azure_login` block supports the following arguments:
+
+* `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
+* `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
+* `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
+
+The `azuread_default_chain_auth` block supports the following arguments:
+
+* `use_oidc` - (Optional) When `true`, authenticates using a federated/OIDC credential (workload identity federation) instead of the default credential chain. Credentials are read from the environment variables below. Defaults to `false`.
+
+When `use_oidc = true`, the following environment variables must be set:
+
+| Variable | Description |
+|---|---|
+| `ARM_TENANT_ID` | Tenant ID of the App Registration |
+| `ARM_CLIENT_ID` | Client ID of the App Registration |
+| `ARM_OIDC_TOKEN` | Signed JWT token (inline). Use this **or** `ARM_OIDC_TOKEN_FILE_PATH`. |
+| `ARM_OIDC_TOKEN_FILE_PATH` | Path to a file containing the signed JWT. The file is re-read on every token refresh. |
+
+The `azuread_managed_identity_auth` block supports the following arguments:
+
+* `user_id` - (Optional) Id of a user-assigned managed identity to assume. Omitting this property instructs the provider to assume a system-assigned managed identity.
+
+-> Only one of `login`, `azure_login`, `azuread_default_chain_auth` and `azuread_managed_identity_auth` can be specified.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `database_id` - The internal numeric ID of the database in `sys.databases`.
+* `collation` - The collation of the database. Populated from the server when not explicitly set.
+
+## Import
+
+Before importing `mssql_database`, you must set the following environment variables: `MSSQL_USERNAME` and `MSSQL_PASSWORD`.
+
+After that you can import the database using the server URL and database name, e.g.
+
+```shell
+terraform import mssql_database.example 'sqlserver://localhost:1433/database/example-db'
+```

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -2,6 +2,17 @@
 
 The `mssql_database` resource allows you to create and manage databases on a SQL Server instance.
 
+## Compatibility
+
+| Platform | Supported | Notes |
+|---|---|---|
+| AWS RDS SQL Server | Yes | Primary use case for this resource. |
+| Azure SQL Managed Instance | Yes | Behaves like on-premises SQL Server. |
+| On-premises / self-hosted SQL Server | Yes | Full support. |
+| Azure SQL Database (PaaS) | **No** | Use [`azurerm_mssql_database`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) from the AzureRM provider instead. This resource will return an error if applied against an Azure SQL Database endpoint. |
+
+> **Azure SQL Database note:** Although `CREATE DATABASE` can technically be executed via T-SQL on Azure SQL Database, doing so bypasses Azure Resource Manager entirely. That means you have no control over service tier, compute size (DTUs/vCores), elastic pool membership, backup retention, or geo-replication — all of which must be configured through the Azure API. Use `azurerm_mssql_database` for Azure SQL Database lifecycle management, then use this provider to manage objects *within* those databases (users, roles, permissions, schemas).
+
 ## Example Usage
 
 ### Basic usage

--- a/mssql/const.go
+++ b/mssql/const.go
@@ -42,4 +42,7 @@ const (
 	keyalgorithmProp       = "key_algorithm"
 	algorithmdescProp      = "algorithm_desc"
 	membersProp            = "members"
+	dbNameProp             = "name"
+	collationProp          = "collation"
+	dbIDProp               = "database_id"
 )

--- a/mssql/datasource_database.go
+++ b/mssql/datasource_database.go
@@ -1,0 +1,77 @@
+package mssql
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/pkg/errors"
+)
+
+func dataSourceDatabase() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDatabaseRead,
+		Schema: map[string]*schema.Schema{
+			serverProp: {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: getServerSchema(serverProp),
+				},
+			},
+			dbNameProp: {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			collationProp: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			dbIDProp: {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Read: defaultTimeout,
+		},
+	}
+}
+
+func dataSourceDatabaseRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logger := loggerFromMeta(meta, "database", "read")
+	logger.Debug().Msgf("Read datasource %s", data.Id())
+
+	name := data.Get(dbNameProp).(string)
+
+	connector, err := getDatabaseConnector(meta, data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	db, err := connector.GetDatabase(ctx, name)
+	if err != nil {
+		return diag.FromErr(errors.Wrapf(err, "unable to get database [%s]", name))
+	}
+
+	if db == nil {
+		return diag.Errorf("database [%s] does not exist", name)
+	}
+
+	if err = data.Set(dbIDProp, db.DatabaseID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = data.Set(dbNameProp, db.DatabaseName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = data.Set(collationProp, db.Collation); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(getDatabaseID(data))
+
+	return nil
+}

--- a/mssql/datasource_database_test.go
+++ b/mssql/datasource_database_test.go
@@ -1,0 +1,92 @@
+package mssql
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataDatabase_Local_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IsUnitTest:        runLocalAccTests,
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      func(state *terraform.State) error { return testAccCheckDataDatabaseDestroy(state) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataDatabase(t, "local_basic", "login", map[string]interface{}{"name": "tf_acc_datasource_db"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "id", "sqlserver://localhost:1433/database/tf_acc_datasource_db"),
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "name", "tf_acc_datasource_db"),
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "server.#", "1"),
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "server.0.host", "localhost"),
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "server.0.port", "1433"),
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "server.0.login.#", "1"),
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "server.0.login.0.username", os.Getenv("MSSQL_USERNAME")),
+					resource.TestCheckResourceAttr("data.mssql_database.local_basic", "server.0.login.0.password", os.Getenv("MSSQL_PASSWORD")),
+					resource.TestCheckResourceAttrSet("data.mssql_database.local_basic", "database_id"),
+					resource.TestCheckResourceAttrSet("data.mssql_database.local_basic", "collation"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataDatabase(t *testing.T, name string, login string, data map[string]interface{}) string {
+	text := `resource "mssql_database" "{{ .label }}" {
+				server {
+					host = "{{ .host }}"
+					{{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+				}
+				name = "{{ .name }}"
+			}
+			data "mssql_database" "{{ .label }}" {
+				server {
+					host = "{{ .host }}"
+					{{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+				}
+				name = "{{ .name }}"
+				depends_on = [mssql_database.{{ .label }}]
+			}`
+
+	data["label"] = name
+	data["login"] = login
+	if login == "fedauth" || login == "msi" || login == "azure" {
+		data["host"] = os.Getenv("TF_ACC_SQL_SERVER")
+	} else if login == "login" {
+		data["host"] = "localhost"
+	} else {
+		t.Fatalf("login expected to be one of 'login', 'azure', 'msi', 'fedauth', got %s", login)
+	}
+	res, err := templateToString(name, text, data)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	return res
+}
+
+func testAccCheckDataDatabaseDestroy(state *terraform.State) error {
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mssql_database" {
+			continue
+		}
+
+		connector, err := getTestConnector(rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		dbName := rs.Primary.Attributes["name"]
+		db, err := connector.GetDatabase(dbName)
+		if db != nil {
+			return fmt.Errorf("database [%s] still exists", dbName)
+		}
+		if err != nil {
+			return fmt.Errorf("expected no error, got %s", err)
+		}
+	}
+	return nil
+}

--- a/mssql/model/database.go
+++ b/mssql/model/database.go
@@ -1,0 +1,8 @@
+package model
+
+// Database represents a SQL Server database
+type Database struct {
+	DatabaseID   int
+	DatabaseName string
+	Collation    string
+}

--- a/mssql/provider.go
+++ b/mssql/provider.go
@@ -47,6 +47,7 @@ func Provider(factory model.ConnectorFactory) *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"mssql_login":                     resourceLogin(),
 			"mssql_user":                      resourceUser(),
+			"mssql_database":                  resourceDatabase(),
 			"mssql_database_permissions":      resourceDatabasePermissions(),
 			"mssql_database_role":             resourceDatabaseRole(),
 			"mssql_database_schema":           resourceDatabaseSchema(),
@@ -61,6 +62,7 @@ func Provider(factory model.ConnectorFactory) *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"mssql_login":                     dataSourceLogin(),
 			"mssql_user":                      dataSourceUser(),
+			"mssql_database":                  dataSourceDatabase(),
 			"mssql_database_permissions":      dataSourceDatabasePermissions(),
 			"mssql_database_role":             dataSourceDatabaseRole(),
 			"mssql_database_schema":           dataSourceDatabaseSchema(),

--- a/mssql/provider_test.go
+++ b/mssql/provider_test.go
@@ -72,6 +72,7 @@ type TestConnector interface {
 	GetEntraIDLogin(name string) (*model.EntraIDLogin, error)
 	GetServerRole(name string) (*model.ServerRole, error)
 	GetServerRoleMember(roleName string, managedMembers []string) (*model.ServerRoleMember, error)
+	GetDatabase(name string) (*model.Database, error)
 	GetSystemUser() (string, error)
 	GetCurrentUser(database string) (string, string, error)
 }
@@ -203,6 +204,10 @@ func (t testConnector) GetEntraIDLogin(name string) (*model.EntraIDLogin, error)
 
 func (t testConnector) GetServerRole(roleName string) (*model.ServerRole, error) {
 	return t.c.(ServerRoleConnector).GetServerRole(context.Background(), roleName)
+}
+
+func (t testConnector) GetDatabase(name string) (*model.Database, error) {
+	return t.c.(DatabaseConnector).GetDatabase(context.Background(), name)
 }
 
 func (t testConnector) GetServerRoleMember(roleName string, managedMembers []string) (*model.ServerRoleMember, error) {

--- a/mssql/resource_database.go
+++ b/mssql/resource_database.go
@@ -60,6 +60,7 @@ func resourceDatabase() *schema.Resource {
 }
 
 type DatabaseConnector interface {
+	GetMSSQLVersion(ctx context.Context) (string, error)
 	CreateDatabase(ctx context.Context, databaseName string, collation string) error
 	GetDatabase(ctx context.Context, databaseName string) (*model.Database, error)
 	UpdateDatabaseCollation(ctx context.Context, databaseName string, collation string) error
@@ -76,6 +77,16 @@ func resourceDatabaseCreate(ctx context.Context, data *schema.ResourceData, meta
 	connector, err := getDatabaseConnector(meta, data)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	version, err := connector.GetMSSQLVersion(ctx)
+	if err != nil {
+		return diag.FromErr(errors.Wrap(err, "unable to get SQL Server version"))
+	}
+	if strings.Contains(version, "Microsoft SQL Azure") {
+		return diag.Errorf("mssql_database is not supported on Azure SQL Database. " +
+			"Use the azurerm_mssql_database resource from the AzureRM provider to manage Azure SQL Database databases. " +
+			"This resource supports AWS RDS SQL Server, Azure SQL Managed Instance, and on-premises SQL Server.")
 	}
 
 	if err = connector.CreateDatabase(ctx, name, collation); err != nil {

--- a/mssql/resource_database.go
+++ b/mssql/resource_database.go
@@ -1,0 +1,232 @@
+package mssql
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/ValeruS/terraform-provider-mssql/mssql/model"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/pkg/errors"
+)
+
+func resourceDatabase() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatabaseCreate,
+		ReadContext:   resourceDatabaseRead,
+		UpdateContext: resourceDatabaseUpdate,
+		DeleteContext: resourceDatabaseDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDatabaseImport,
+		},
+		Schema: map[string]*schema.Schema{
+			serverProp: {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: getServerSchema(serverProp),
+				},
+			},
+			dbNameProp: {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			collationProp: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^[a-zA-Z0-9_]+$`),
+					"collation must only contain letters, numbers, and underscores",
+				),
+			},
+			dbIDProp: {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: defaultTimeout,
+			Read:   defaultTimeout,
+			Update: defaultTimeout,
+			Delete: defaultTimeout,
+		},
+	}
+}
+
+type DatabaseConnector interface {
+	CreateDatabase(ctx context.Context, databaseName string, collation string) error
+	GetDatabase(ctx context.Context, databaseName string) (*model.Database, error)
+	UpdateDatabaseCollation(ctx context.Context, databaseName string, collation string) error
+	DeleteDatabase(ctx context.Context, databaseName string) error
+}
+
+func resourceDatabaseCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logger := loggerFromMeta(meta, "database", "create")
+	logger.Debug().Msgf("Create %s", getDatabaseID(data))
+
+	name := data.Get(dbNameProp).(string)
+	collation := data.Get(collationProp).(string)
+
+	connector, err := getDatabaseConnector(meta, data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = connector.CreateDatabase(ctx, name, collation); err != nil {
+		return diag.FromErr(errors.Wrapf(err, "unable to create database [%s]", name))
+	}
+
+	data.SetId(getDatabaseID(data))
+
+	logger.Info().Msgf("created database [%s]", name)
+
+	return resourceDatabaseRead(ctx, data, meta)
+}
+
+func resourceDatabaseRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logger := loggerFromMeta(meta, "database", "read")
+	logger.Debug().Msgf("Read %s", data.Id())
+
+	name := data.Get(dbNameProp).(string)
+
+	connector, err := getDatabaseConnector(meta, data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	db, err := connector.GetDatabase(ctx, name)
+	if err != nil {
+		return diag.FromErr(errors.Wrapf(err, "unable to get database [%s]", name))
+	}
+
+	if db == nil {
+		logger.Info().Msgf("database [%s] does not exist", name)
+		data.SetId("")
+	} else {
+		if err = data.Set(dbIDProp, db.DatabaseID); err != nil {
+			return diag.FromErr(err)
+		}
+		if err = data.Set(dbNameProp, db.DatabaseName); err != nil {
+			return diag.FromErr(err)
+		}
+		if err = data.Set(collationProp, db.Collation); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	logger.Info().Msgf("read database [%s]", name)
+
+	return nil
+}
+
+func resourceDatabaseUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logger := loggerFromMeta(meta, "database", "update")
+	logger.Debug().Msgf("Update %s", data.Id())
+
+	name := data.Get(dbNameProp).(string)
+
+	connector, err := getDatabaseConnector(meta, data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if data.HasChange(collationProp) {
+		oldCollation, _ := data.GetChange(collationProp)
+		newCollation := data.Get(collationProp).(string)
+		if err = connector.UpdateDatabaseCollation(ctx, name, newCollation); err != nil {
+			if setErr := data.Set(collationProp, oldCollation); setErr != nil {
+				logger.Error().Err(setErr).Msg("Failed to revert collation state after update error")
+			}
+			return diag.FromErr(errors.Wrapf(err, "unable to update collation for database [%s]", name))
+		}
+	}
+
+	logger.Info().Msgf("updated database [%s]", name)
+
+	return resourceDatabaseRead(ctx, data, meta)
+}
+
+func resourceDatabaseDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	logger := loggerFromMeta(meta, "database", "delete")
+	logger.Debug().Msgf("Delete %s", data.Id())
+
+	name := data.Get(dbNameProp).(string)
+
+	connector, err := getDatabaseConnector(meta, data)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = connector.DeleteDatabase(ctx, name); err != nil {
+		return diag.FromErr(errors.Wrapf(err, "unable to delete database [%s]", name))
+	}
+
+	data.SetId("")
+
+	logger.Info().Msgf("deleted database [%s]", name)
+
+	return nil
+}
+
+func resourceDatabaseImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	logger := loggerFromMeta(meta, "database", "import")
+	logger.Debug().Msgf("Import %s", data.Id())
+
+	server, u, err := serverFromId(data.Id())
+	if err != nil {
+		return nil, err
+	}
+	if err := data.Set(serverProp, server); err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(u.Path, "/")
+	if len(parts) != 3 {
+		return nil, errors.New("invalid ID: expected sqlserver://host:port/database/db_name")
+	}
+	if err = data.Set(dbNameProp, parts[2]); err != nil {
+		return nil, err
+	}
+
+	data.SetId(getDatabaseID(data))
+
+	name := data.Get(dbNameProp).(string)
+
+	connector, err := getDatabaseConnector(meta, data)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := connector.GetDatabase(ctx, name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get database [%s]", name)
+	}
+
+	if db == nil {
+		return nil, errors.Errorf("database [%s] does not exist", name)
+	}
+
+	if err = data.Set(dbIDProp, db.DatabaseID); err != nil {
+		return nil, err
+	}
+	if err = data.Set(collationProp, db.Collation); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{data}, nil
+}
+
+func getDatabaseConnector(meta interface{}, data *schema.ResourceData) (DatabaseConnector, error) {
+	provider := meta.(model.Provider)
+	connector, err := provider.GetConnector(serverProp, data)
+	if err != nil {
+		return nil, err
+	}
+	return connector.(DatabaseConnector), nil
+}

--- a/mssql/resource_database_test.go
+++ b/mssql/resource_database_test.go
@@ -1,0 +1,213 @@
+package mssql
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDatabase_Local_Basic_Create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IsUnitTest:        runLocalAccTests,
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      func(state *terraform.State) error { return testAccCheckDatabaseDestroy(state) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatabase(t, "local_basic_create", "login", map[string]interface{}{"name": "tf_acc_test_db_create"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseExists("mssql_database.local_basic_create"),
+					resource.TestCheckResourceAttr("mssql_database.local_basic_create", "name", "tf_acc_test_db_create"),
+					resource.TestCheckResourceAttr("mssql_database.local_basic_create", "server.#", "1"),
+					resource.TestCheckResourceAttr("mssql_database.local_basic_create", "server.0.host", "localhost"),
+					resource.TestCheckResourceAttr("mssql_database.local_basic_create", "server.0.port", "1433"),
+					resource.TestCheckResourceAttr("mssql_database.local_basic_create", "server.0.login.#", "1"),
+					resource.TestCheckResourceAttr("mssql_database.local_basic_create", "server.0.login.0.username", os.Getenv("MSSQL_USERNAME")),
+					resource.TestCheckResourceAttr("mssql_database.local_basic_create", "server.0.login.0.password", os.Getenv("MSSQL_PASSWORD")),
+					resource.TestCheckResourceAttrSet("mssql_database.local_basic_create", "database_id"),
+					resource.TestCheckResourceAttrSet("mssql_database.local_basic_create", "collation"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabase_Local_Basic_Create_Collation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IsUnitTest:        runLocalAccTests,
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      func(state *terraform.State) error { return testAccCheckDatabaseDestroy(state) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatabase(t, "local_collation_create", "login", map[string]interface{}{
+					"name":      "tf_acc_test_db_collation",
+					"collation": "SQL_Latin1_General_CP1_CI_AS",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseExists("mssql_database.local_collation_create",
+						Check{"collation", "==", "SQL_Latin1_General_CP1_CI_AS"},
+					),
+					resource.TestCheckResourceAttr("mssql_database.local_collation_create", "name", "tf_acc_test_db_collation"),
+					resource.TestCheckResourceAttr("mssql_database.local_collation_create", "collation", "SQL_Latin1_General_CP1_CI_AS"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabase_Local_Basic_Update_Collation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IsUnitTest:        runLocalAccTests,
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      func(state *terraform.State) error { return testAccCheckDatabaseDestroy(state) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatabase(t, "local_collation_update", "login", map[string]interface{}{
+					"name":      "tf_acc_test_db_coll_update",
+					"collation": "SQL_Latin1_General_CP1_CI_AS",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseExists("mssql_database.local_collation_update",
+						Check{"collation", "==", "SQL_Latin1_General_CP1_CI_AS"},
+					),
+					resource.TestCheckResourceAttr("mssql_database.local_collation_update", "collation", "SQL_Latin1_General_CP1_CI_AS"),
+				),
+			},
+			{
+				Config: testAccCheckDatabase(t, "local_collation_update", "login", map[string]interface{}{
+					"name":      "tf_acc_test_db_coll_update",
+					"collation": "SQL_Latin1_General_CP1_CS_AS",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseExists("mssql_database.local_collation_update",
+						Check{"collation", "==", "SQL_Latin1_General_CP1_CS_AS"},
+					),
+					resource.TestCheckResourceAttr("mssql_database.local_collation_update", "collation", "SQL_Latin1_General_CP1_CS_AS"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabase_Local_Import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		IsUnitTest:        runLocalAccTests,
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      func(state *terraform.State) error { return testAccCheckDatabaseDestroy(state) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDatabase(t, "local_import", "login", map[string]interface{}{"name": "tf_acc_test_db_import"}),
+			},
+			{
+				ResourceName:      "mssql_database.local_import",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccImportStateId("mssql_database.local_import", false),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabase(t *testing.T, name string, login string, data map[string]interface{}) string {
+	text := `resource "mssql_database" "{{ .label }}" {
+				server {
+					host = "{{ .host }}"
+					{{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
+				}
+				name = "{{ .name }}"
+				{{ with .collation }}collation = "{{ . }}"{{ end }}
+			}`
+
+	data["label"] = name
+	data["login"] = login
+	if login == "fedauth" || login == "msi" || login == "azure" {
+		data["host"] = os.Getenv("TF_ACC_SQL_SERVER")
+	} else if login == "login" {
+		data["host"] = "localhost"
+	} else {
+		t.Fatalf("login expected to be one of 'login', 'azure', 'msi', 'fedauth', got %s", login)
+	}
+	res, err := templateToString(name, text, data)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	return res
+}
+
+func testAccCheckDatabaseDestroy(state *terraform.State) error {
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mssql_database" {
+			continue
+		}
+
+		connector, err := getTestConnector(rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		dbName := rs.Primary.Attributes["name"]
+		db, err := connector.GetDatabase(dbName)
+		if db != nil {
+			return fmt.Errorf("database [%s] still exists", dbName)
+		}
+		if err != nil {
+			return fmt.Errorf("expected no error, got %s", err)
+		}
+	}
+	return nil
+}
+
+func testAccCheckDatabaseExists(resource string, checks ...Check) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("not found: %s", resource)
+		}
+		if rs.Type != "mssql_database" {
+			return fmt.Errorf("expected resource of type %s, got %s", "mssql_database", rs.Type)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no record ID is set")
+		}
+
+		connector, err := getTestConnector(rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		dbName := rs.Primary.Attributes["name"]
+		db, err := connector.GetDatabase(dbName)
+		if err != nil {
+			return fmt.Errorf("error fetching database: %s", err)
+		}
+		if db == nil {
+			return fmt.Errorf("database [%s] does not exist", dbName)
+		}
+		if db.DatabaseName != dbName {
+			return fmt.Errorf("expected database name %s, got %s", dbName, db.DatabaseName)
+		}
+
+		for _, check := range checks {
+			var actual interface{}
+			switch check.name {
+			case "collation":
+				actual = db.Collation
+			default:
+				return fmt.Errorf("unknown property %s", check.name)
+			}
+			if (check.op == "" || check.op == "==") && !equal(check.expected, actual) {
+				return fmt.Errorf("expected %s == %s, got %s", check.name, check.expected, actual)
+			}
+			if check.op == "!=" && equal(check.expected, actual) {
+				return fmt.Errorf("expected %s != %s, got %s", check.name, check.expected, actual)
+			}
+		}
+		return nil
+	}
+}

--- a/mssql/utils.go
+++ b/mssql/utils.go
@@ -88,6 +88,13 @@ func getServerRoleID(data *schema.ResourceData) string {
 	return fmt.Sprintf("sqlserver://%s:%s/role/%s", host, port, roleName)
 }
 
+func getDatabaseID(data *schema.ResourceData) string {
+	host := data.Get(serverProp + ".0.host").(string)
+	port := data.Get(serverProp + ".0.port").(string)
+	name := data.Get(dbNameProp).(string)
+	return fmt.Sprintf("sqlserver://%s:%s/database/%s", host, port, name)
+}
+
 func getServerRoleMemberID(data *schema.ResourceData) string {
 	host := data.Get(serverProp + ".0.host").(string)
 	port := data.Get(serverProp + ".0.port").(string)

--- a/sql/database.go
+++ b/sql/database.go
@@ -1,0 +1,65 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/ValeruS/terraform-provider-mssql/mssql/model"
+)
+
+func (c *Connector) GetDatabase(ctx context.Context, databaseName string) (*model.Database, error) {
+	cmd := `SELECT database_id, name, collation_name
+			FROM [sys].[databases]
+			WHERE [name] = @databaseName`
+	var db model.Database
+	err := c.QueryRowContext(ctx, cmd,
+		func(r *sql.Row) error {
+			return r.Scan(&db.DatabaseID, &db.DatabaseName, &db.Collation)
+		},
+		sql.Named("databaseName", databaseName),
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &db, nil
+}
+
+func (c *Connector) CreateDatabase(ctx context.Context, databaseName string, collation string) error {
+	cmd := `DECLARE @sql nvarchar(max)
+			IF @collation = ''
+				BEGIN
+					SET @sql = 'CREATE DATABASE ' + QuoteName(@databaseName)
+				END
+			ELSE
+				BEGIN
+					SET @sql = 'CREATE DATABASE ' + QuoteName(@databaseName) + ' COLLATE ' + @collation
+				END
+			EXEC (@sql)`
+	return c.ExecContext(ctx, cmd,
+		sql.Named("databaseName", databaseName),
+		sql.Named("collation", collation),
+	)
+}
+
+func (c *Connector) UpdateDatabaseCollation(ctx context.Context, databaseName string, collation string) error {
+	cmd := `DECLARE @sql nvarchar(max)
+			SET @sql = 'ALTER DATABASE ' + QuoteName(@databaseName) + ' COLLATE ' + @collation
+			EXEC (@sql)`
+	return c.ExecContext(ctx, cmd,
+		sql.Named("databaseName", databaseName),
+		sql.Named("collation", collation),
+	)
+}
+
+func (c *Connector) DeleteDatabase(ctx context.Context, databaseName string) error {
+	cmd := `DECLARE @sql nvarchar(max)
+			SET @sql = 'IF EXISTS (SELECT 1 FROM [sys].[databases] WHERE [name] = ' + QuoteName(@databaseName, '''') + ') ' +
+						'DROP DATABASE ' + QuoteName(@databaseName)
+			EXEC (@sql)`
+	return c.ExecContext(ctx, cmd,
+		sql.Named("databaseName", databaseName),
+	)
+}


### PR DESCRIPTION
My team is working with MSSQL on RDS and has need of a resource type to create databases.  This was important to us since we use Terraform to provision the RDS instance, databases within it, and logins/users for those databases.  Having a partial Terraform apply/failure, then manual steps to create databases, then running TF again to create the users was painful.

I am neither a Go developer, nor a Terraform module developer, so I leaned on Claude to help generate this code.  I did manually review it afterwards, and run the acceptance test suite, but if you have concerns about AI-assisted code, you may of course want to stop reading here.

I also have not tested this resource type on Azure; we're an AWS-only org. I am reasonably sure that would be a bad idea to use it on an Azure SQL PaaS, and have added guards to prevent that.  However, for Azure Managed Instances and non-Azure environments, it seems like a good fit.