### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ValeruS/terraform-provider-mssql/security/code-scanning/4](https://github.com/ValeruS/terraform-provider-mssql/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/tests.yml` so all jobs inherit least-privilege token access unless overridden.  
The safest minimal fix, aligned with CodeQL guidance and current workflow behavior, is:

```yaml
permissions:
  contents: read
```

This preserves functionality for `actions/checkout` and typical read-only CI operations while documenting and enforcing least privilege. No imports, methods, or dependencies are needed—just a YAML update near the top of the workflow (after `on:` and before `jobs:` is a clean placement).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
