### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ValeruS/terraform-provider-mssql/security/code-scanning/2](https://github.com/ValeruS/terraform-provider-mssql/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/release.yml` so `GITHUB_TOKEN` uses least privilege and does not rely on repo/org defaults.

Best single fix (without changing intended functionality): add workflow-level permissions directly under `on:` (or under `name:`) so it applies to all jobs in this workflow. For this release pipeline, `contents: write` is required to create/update GitHub releases and upload assets; `contents: read` would likely break publishing. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
